### PR TITLE
Add docker volume for lemmy-ui extra_themes folder

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - LEMMY_INTERNAL_HOST=lemmy:8536
       - LEMMY_EXTERNAL_HOST={{ domain }}
       - LEMMY_HTTPS=true
+    volumes:
+      - ./volumes/lemmy-ui/extra_themes:/app/extra_themes
     depends_on: 
       - lemmy
 


### PR DESCRIPTION
You can test it on enterprise.lemmy.ml, i added a custom theme named "test" (which is just the nord theme under a different name).