### PR TITLE
Rename rate_limit with domain name space

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,4 +1,4 @@
-limit_req_zone $binary_remote_addr zone=lemmy_ratelimit:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone={{domain}}_ratelimit:10m rate=1r/s;
 
 server {
     listen 80;
@@ -84,7 +84,7 @@ server {
       proxy_set_header Connection "upgrade";
 
       # Rate limit
-      limit_req zone=lemmy_ratelimit burst=30 nodelay;
+      limit_req zone={{domain}}_ratelimit burst=30 nodelay;
 
       # Add IP forwarding headers
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This allows to provision one lemmy instance in a server where there are already other lemmy instances installed with this same nginx template.
Currently, nginx refuses to reload starting at the 2d instance installed, because lemmy_ratelimit is already defined in another site conf.
It also makes sense to just give each lemmy its own rate limit strategy instead of sharing a host-global one.