### PR TITLE
Revert back to installing Docker from Ubuntu repos (fixes #61)

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -33,42 +33,10 @@
       update_cache: true
       pkg:
         - 'nginx'
+        - 'docker-compose'
+        - 'docker.io'
         - 'certbot'
         - 'python3-certbot-nginx'
-        - 'apt-transport-https'
-        - 'ca-certificates'
-        - 'curl'
-        - 'software-properties-common'
-        - 'python3-pip'
-        - 'virtualenv'
-        - 'python3-setuptools'
-
-  - name: Add Docker GPG apt Key
-    apt_key:
-      url: https://download.docker.com/linux/ubuntu/gpg
-      state: present
-
-  - name: Add Docker Repository
-    apt_repository:
-      repo: deb https://download.docker.com/linux/ubuntu focal stable
-      state: present
-
-  - name: Update apt and install docker-ce
-    apt:
-      name: docker-ce
-      state: latest
-      update_cache: true
-
-  - name: Install Docker Module for Python
-    pip:
-      name: docker
-
-  - name: Install or upgrade docker-compose
-    get_url: 
-      url : "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-Linux-x86_64"
-      dest: /usr/local/bin/docker-compose
-      mode: 'a+x'
-      force: yes
 
   - name: copy docker config
     copy: src='../files/docker-daemon.json' dest='/etc/docker/daemon.json' mode='0644'


### PR DESCRIPTION
Installing from Docker repos adds more complexity and potential failure modes like in the linked issue, without offering any tangible benefit. Lets keep using the old installation method which totally fine.