### PR TITLE
Install latest docker/docker-compose via pip. Proposed as fix for #67

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -62,13 +62,12 @@
   - name: Install Docker Module for Python
     pip:
       name: docker
+      state: latest
 
   - name: Install or upgrade docker-compose
-    get_url: 
-      url : "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-Linux-x86_64"
-      dest: /usr/local/bin/docker-compose
-      mode: 'a+x'
-      force: yes
+    pip:
+      name: docker-compose
+      state: latest
 
   - name: copy docker config
     copy: src='../files/docker-daemon.json' dest='/etc/docker/daemon.json' mode='0644'

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -59,14 +59,11 @@
       state: latest
       update_cache: true
 
-  - name: Install Docker Module for Python
+  - name: Install Docker Module and docker-compose for Python
     pip:
-      name: docker
-      state: latest
-
-  - name: Install or upgrade docker-compose
-    pip:
-      name: docker-compose
+      name:
+        - docker
+        - docker-compose
       state: latest
 
   - name: copy docker config


### PR DESCRIPTION
I was getting the same docker-compose error seen in #67 .  This installs `docker-compose` the same way that `docker` is installed, and a proper entry point is already created in the expected location `/usr/local/bin/docker-compose`.  I have been able to complete and test a deployment on a fresh ubuntu-22.04-x86_64 instance with this change.