### PR TITLE
Add inbox to nginx.conf backend routes

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -77,7 +77,7 @@ server {
     }
 
     # backend
-    location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
+    location ~ ^/(api|pictrs|feeds|inbox|nodeinfo|.well-known) {
       proxy_pass http://0.0.0.0:{{lemmy_port}};
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
I can see in the nginx log that requests are being sent to an `/inbox` route, and it looks like these requests ought to be directed to the backend. This PR makes a small change to nginx.conf to make this happen by default.

See https://lemmy.ml/post/1148327?scrollToComments=true