### PR TITLE
Forward host headers from external to internal nginx

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -25,6 +25,9 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }
 


### PR DESCRIPTION
This fixes issue raised here: https://github.com/LemmyNet/lemmy/issues/3273

IP and host were not being forwarded, causing http signature verification to fail with message `Incoming activity has invalid signature`