### PR TITLE
Update docker-compose.yml

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -110,6 +110,9 @@ services:
 
   postfix:
     image: mwader/postfix-relay
+    networks:
+      - lemmyinternal
+      - lemmyexternalproxy
     environment:
       - POSTFIX_myhostname={{ domain }}
     restart: "always"


### PR DESCRIPTION


Updated docker-compose file as the postfix service needed the ability to access the lemmyinternal network and the lemmyexternal network. This allows the lemmy container to be able to reach the `postfix` dns name. The external network allows for it to be able to ping and resolve external hostnames.