### PR TITLE
Clean up networks in docker-compose.yml

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -7,18 +7,22 @@ x-logging: &default-logging
     max-file: "4"
 
 networks:
-  # communication to web and clients
-  lemmyexternalproxy:
+  default:
   # communication between lemmy services
   lemmyinternal:
     driver: bridge
-    internal: true
+  # communication to web and clients
+  lemmyexternalproxy:
+    driver: bridge
 services:
   proxy:
     image: nginx:1-alpine
+    hostname: proxy
     networks:
-      - lemmyinternal
-      - lemmyexternalproxy
+      lemmyinternal:
+        priority: 10
+      lemmyexternalproxy:
+        priority: 1000
     ports:
       # actual and only port facing any connection from outside
       # Note, change the left number if port 1236 is already in use on your system
@@ -37,7 +41,6 @@ services:
     hostname: lemmy
     networks:
       - lemmyinternal
-      - lemmyexternalproxy
     restart: always
     logging: *default-logging
     environment:
@@ -50,9 +53,9 @@ services:
 
   lemmy-ui:
     image: {{ lemmy_docker_ui_image }}
+    hostname: lemmy-ui
     networks:
       - lemmyinternal
-      - lemmyexternalproxy
     environment:
       - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
       - LEMMY_UI_LEMMY_EXTERNAL_HOST={{ domain }}
@@ -72,7 +75,6 @@ services:
     # entrypoint: /sbin/tini -- /usr/local/bin/pict-rs -p /mnt -m 4 --image-format webp
     networks:
       - lemmyinternal
-      - lemmyexternalproxy
     environment:
       - PICTRS_OPENTELEMETRY_URL=http://otel:4137
       - PICTRS__API_KEY=API_KEY
@@ -109,6 +111,8 @@ services:
     logging: *default-logging
 
   postfix:
+    networks:
+      - lemmyinternal
     image: mwader/postfix-relay
     environment:
       - POSTFIX_myhostname={{ domain }}

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -7,13 +7,12 @@ x-logging: &default-logging
     max-file: "4"
 
 networks:
-  default:
+  # communication to web and clients
+  lemmyexternalproxy:
   # communication between lemmy services
   lemmyinternal:
     driver: bridge
-  # communication to web and clients
-  lemmyexternalproxy:
-    driver: bridge
+    internal: true
 services:
   proxy:
     image: nginx:1-alpine
@@ -40,7 +39,10 @@ services:
     image: {{ lemmy_docker_image }}
     hostname: lemmy
     networks:
-      - lemmyinternal
+      lemmyinternal:
+        priority: 100
+      lemmyexternalproxy:
+        priority: 10
     restart: always
     logging: *default-logging
     environment:
@@ -74,7 +76,10 @@ services:
     # we can set options to pictrs like this, here we set max. image size and forced format for conversion
     # entrypoint: /sbin/tini -- /usr/local/bin/pict-rs -p /mnt -m 4 --image-format webp
     networks:
-      - lemmyinternal
+      lemmyinternal:
+        priority: 100
+      lemmyexternalproxy:
+        priority: 10
     environment:
       - PICTRS_OPENTELEMETRY_URL=http://otel:4137
       - PICTRS__API_KEY=API_KEY
@@ -112,7 +117,10 @@ services:
 
   postfix:
     networks:
-      - lemmyinternal
+      lemmyinternal:
+        priority: 100
+      lemmyexternalproxy:
+        priority: 10
     image: mwader/postfix-relay
     environment:
       - POSTFIX_myhostname={{ domain }}


### PR DESCRIPTION
This commit removes the "internal" boolean from the "lemmyinternal" network, explicitly defines hostnames for each container (matching existing hostnames if found elsewhere like in env variables), ensures the nginx container connects to the "lemmyexternalproxy" network first, and places the containers in the appropriate network(s).

I'm really not sure what the "internal" boolean on the "lemmyinternal" network brings, as the containers that need WAN access wouldn't be able to get it unless they're _also_ connected to the "lemmyexternalproxy" network and could egress through that route, which defeats the purpose of having them connected to a restricted network. If the idea is to restrict access/traffic to only the containers within that network, but still allow WAN egress from them, it might make more sense to have the internal nginx container also act as a forward proxy for those containers in addition to the reverse proxy role it's already serving.

Not every container had an explicit hostname, so sometimes traffic meant for one container would actually go to a different one. The postfix container also didn't have an explicit network assignment, so it would fall off onto its own subnet in the default network.