### PR TITLE
Use nginx regexp to accept multiple Accept header content

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -37,10 +37,10 @@ http {
             # don't change lemmy-ui or lemmy here, they refer to the upstream definitions on top
             set $proxpass "http://lemmy-ui";
 
-            if ($http_accept = "application/activity+json") {
+            if ($http_accept ~* "application\\/activity\\+json,*") {
               set $proxpass "http://lemmy";
             }
-            if ($http_accept = "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"") {
+            if ($http_accept ~* "application\\/ld\\+json; profile=\"https://www.w3.org/ns/activitystreams\",*") {
               set $proxpass "http://lemmy";
             }
             if ($request_method = POST) {


### PR DESCRIPTION
This patch utilizes regular expression to attempt properly route in the case of multiple accept header content.

Fixes issue #106 