### PR TITLE
Fix: Use nginx map + regexp to accept multiple Accept header values

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -1,12 +1,46 @@
 worker_processes auto;
+
 events {
     worker_connections 1024;
 }
+
 http {
+    # We construct a string consistent of the "request method" and "http accept header"
+    # and then apply soem ~simply regexp matches to that combination to decide on the
+    # HTTP upstream we should proxy the request to.
+    #
+    # Example strings:
+    #
+    #   "GET:application/activity+json"
+    #   "GET:text/html"
+    #   "POST:application/activity+json"
+    #
+    # You can see some basic match tests in this regex101 matching this configuration
+    # https://regex101.com/r/vwMJNc/1
+    #
+    # Learn more about nginx maps here http://nginx.org/en/docs/http/ngx_http_map_module.html
+    map "$request_method:$http_accept" $proxpass {
+        # If no explicit matches exists below, send traffic to lemmy-ui
+        default "http://lemmy-ui";
+
+        # GET/HEAD requests that accepts ActivityPub or Linked Data JSON should go to lemmy.
+        #
+        # These requests are used by Mastodon and other fediverse instances to look up profile information,
+        # discover site information and so on.
+        "~^(?:GET|HEAD):.*?application\/(?:activity|ld)\+json" "http://lemmy";
+
+        # All non-GET/HEAD requests should go to lemmy
+        #
+        # Rather than calling out POST, PUT, DELETE, PATCH, CONNECT and all the verbs manually
+        # we simply negate the GET|HEAD pattern from above and accept all possibly $http_accept values
+        "~^(?!(GET|HEAD)).*:" "http://lemmy";
+    }
+
     upstream lemmy {
         # this needs to map to the lemmy (server) docker service hostname
         server "lemmy:8536";
     }
+
     upstream lemmy-ui {
         # this needs to map to the lemmy-ui docker service hostname
         server "lemmy-ui:1234";
@@ -16,6 +50,7 @@ http {
         # this is the port inside docker, not the public one yet
         listen 1236;
         listen 8536;
+
         # change if needed, this is facing the public web
         server_name localhost;
         server_tokens off;
@@ -33,22 +68,10 @@ http {
 
         # frontend general requests
         location / {
-            # distinguish between ui requests and backend
-            # don't change lemmy-ui or lemmy here, they refer to the upstream definitions on top
-            set $proxpass "http://lemmy-ui";
-
-            if ($http_accept = "application/activity+json") {
-              set $proxpass "http://lemmy";
-            }
-            if ($http_accept = "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"") {
-              set $proxpass "http://lemmy";
-            }
-            if ($request_method = POST) {
-              set $proxpass "http://lemmy";
-            }
             proxy_pass $proxpass;
 
             rewrite ^(.+)/+$ $1 permanent;
+
             # Send actual client IP upstream
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
@@ -58,6 +81,7 @@ http {
         # backend
         location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
             proxy_pass "http://lemmy";
+
             # proxy common stuff
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Fixes https://github.com/LemmyNet/lemmy-ansible/issues/106
Supersedes https://github.com/LemmyNet/lemmy-ansible/pull/107

I've tested that

* My Mastodon server can find both users and communities correctly
* Signing up/changing settings in the lemmy UI continues to work
* Can post comments and new content via lemmy UI

I've added some context in the code to explain the change, link to some regex tests (for future contributors/bug fixing in the future) and links to the relevant documentation for nnginx