### PR TITLE
server tokens on port 80 host still exposed

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -4,6 +4,8 @@ server {
     listen 80;
     listen [::]:80;
     server_name {{domain}};
+    # Hide nginx version
+    server_tokens off;
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }


### PR DESCRIPTION
On port 80 the nginx version is still exposed, this is only a fix on the lemmy host. A better way is to disabled it global. But then other files of nginx should be touched.