### PR TITLE
configure jammy++ docker binaries

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -45,7 +45,7 @@
           - "python3-setuptools"
 
     - name: Configure Docker apt repo before Jammy
-      #when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'
       block:
         - name: Add Docker GPG apt Key
           apt_key:

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -38,20 +38,36 @@
           - "apt-transport-https"
           - "ca-certificates"
           - "curl"
+          - "gnupg"
           - "software-properties-common"
           - "python3-pip"
           - "virtualenv"
           - "python3-setuptools"
 
-    - name: Add Docker GPG apt Key
-      apt_key:
-        url: https://download.docker.com/linux/ubuntu/gpg
-        state: present
+    - name: Configure Docker apt repo before Jammy
+      #when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'
+      block:
+        - name: Add Docker GPG apt Key
+          apt_key:
+            url: https://download.docker.com/linux/ubuntu/gpg
+            state: present
+        - name: Add Docker Repository
+          apt_repository:
+            repo: deb https://download.docker.com/linux/ubuntu focal stable
+            state: present
 
-    - name: Add Docker Repository
-      apt_repository:
-        repo: deb https://download.docker.com/linux/ubuntu focal stable
-        state: present
+    - name: Configure Docker apt repo on Jammy++
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '24.04'
+      block:
+        - name: Download Docker GPG Key
+          get_url:
+            url: https://download.docker.com/linux/ubuntu/gpg
+            dest: /etc/apt/keyrings/docker.asc
+            checksum: sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
+        - name: Add Docker to apt
+          apt_repository:
+            repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+            state: present
 
     - name: Update apt and install docker-ce
       apt:


### PR DESCRIPTION
lemmy-ansible uses deprecated `apt-key` and Docker's apt repo is only configured for Ubuntu 20.04 (Focal) binaries.

To reproduce run lemmy-ansible on an Ubuntu 22.04 (Jammy) vm. Login and check apt configuration:
```shell
eslerm@sec-jammy-amd64:~$ sudo cat /etc/apt/sources.list.d/download_docker_com_linux_ubuntu.list
deb https://download.docker.com/linux/ubuntu focal stable
```
```shell
eslerm@sec-jammy-amd64:~$ sudo apt update
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:3 https://download.docker.com/linux/ubuntu focal InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
35 packages can be upgraded. Run 'apt list --upgradable' to see them.
W: https://download.docker.com/linux/ubuntu/dists/focal/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
N: Skipping acquire of configured file 'stable/binary-i386/Packages' as repository 'https://download.docker.com/linux/ubuntu focal InRelease' doesn't support architecture 'i386'
```

This commit makes apt configuration conditional on release number. The pre-Jammy configurations were left as is. Jammy++ configs adapt to ansible_distribution_release (i.e., jammy, kinetic, lunar, and mantic get the correct binaries) and use the `signed-by` apt config, which replaces `apt-key` and is [suggested by Docker](https://docs.docker.com/engine/install/ubuntu/). I did not dearmor the key as Docker suggested for Ansible convinence. Please verify the checksum. The README.me says that Debian-based vms are supported, but that's was not the case for Docker binaries before or with this commit.

I tested the patch on Focal, Jammy, and Lunar. Focal and Lunar failed after apt config unrelated preexisting issues (https://github.com/LemmyNet/lemmy-ansible/issues/54 in the case of Lunar). This fixes https://github.com/LemmyNet/lemmy-ansible/issues/61 and partially resolves https://github.com/LemmyNet/lemmy-ansible/issues/82