### PR TITLE
Link to github releases page instead of RELEASES.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To run this ansible playbook, you need to:
 ## Upgrading
 
 - Run `git pull`
-- Check out the [Lemmy Releases Changelog](https://github.com/LemmyNet/lemmy/blob/main/RELEASES.md) to see if there are any config changes with the releases since your last.
+- Check out the [Lemmy Releases Changelog](https://github.com/LemmyNet/lemmy/releases) to see if there are any config changes with the releases since your last.
 - Run `ansible-playbook -i inventory/hosts lemmy.yml --become`
 
 ## Migrating your existing install to use this deploy


### PR DESCRIPTION
This change updates a link in README.md so that it points to the github releases page instead of RELEASES.md. It doesn't look as if RELEASES.md is kept up to date. RELEASES.md was last updated 5 months ago.