### PR TITLE
Fix: Remove Lemmy port from NGINX server listen block

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -49,7 +49,6 @@ http {
     server {
         # this is the port inside docker, not the public one yet
         listen 1236;
-        listen 8536;
 
         # change if needed, this is facing the public web
         server_name localhost;


### PR DESCRIPTION
Fix: LemmyNet/lemmy-ansible/issues/127