### PR TITLE
Reduce repetition in NGINX configuration

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -66,16 +66,15 @@ http {
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
 
+        # Send actual client IP upstream
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
         # frontend general requests
         location / {
             proxy_pass $proxpass;
-
             rewrite ^(.+)/+$ $1 permanent;
-
-            # Send actual client IP upstream
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         # backend
@@ -86,11 +85,6 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-
-            # Send actual client IP upstream
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     }
 }


### PR DESCRIPTION
Moves common proxy stuff to the server level as they're the same. This is for #133 so that we don't copy paste those lines a third time