### PR TITLE
Add `client_max_body_size` to external NGINX config

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -35,6 +35,9 @@ server {
     # Hide nginx version
     server_tokens off;
 
+    # Upload limit, relevant for pictrs
+    client_max_body_size 20M;
+
     # Enable compression for JS/CSS/HTML bundle, for improved client load times.
     # It might be nice to compress JSON, but leaving that out to protect against potential
     # compression+encryption information leak attacks like BREACH.


### PR DESCRIPTION
Upon creating a new Lemmy instance I was unable to upload images over 1024KB, I noticed `nignx_internal.conf` has a setting for `client_max_body_size` which was missing on `nginx.conf`, appending it here.