### PR TITLE
Enable pictrs s3 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ To run this ansible playbook, you need to:
 
    You must copy it into `inventory/host_vars/` and rename it to the inventory
    hostname set in `hosts` file. For example, if the inventory hostname is:
-   
+
    `user@lemmy.example.com`
-   
+
    then the file must be named:
-   
+
    `user@lemmy.example.com.yml`
-   
+
    Remember the `.yml` extension!
-   
+
    Links to additional documentation can be found in the file.
 
 7. Run the playbook:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,22 @@ To run this ansible playbook, you need to:
 
    You can use [the PGTune tool](https://pgtune.leopard.in.ua) to tune your postgres to meet your server memory and CPU.
 
-6. Run the playbook:
+6. (Optional) If you need advanced configurations, copy the sample additional_host_var.yml file:
+
+   You must copy it into `inventory/host_vars/` and rename it to the inventory
+   hostname set in `hosts` file. For example, if the inventory hostname is:
+   
+   `user@lemmy.example.com`
+   
+   then the file must be named:
+   
+   `user@lemmy.example.com.yml`
+   
+   Remember the `.yml` extension!
+   
+   Links to additional documentation can be found in the file.
+
+7. Run the playbook:
 
    `ansible-playbook -i inventory/hosts lemmy.yml`
 

--- a/examples/additional_host_vars.yml
+++ b/examples/additional_host_vars.yml
@@ -1,0 +1,34 @@
+---
+##############################################################################
+# This file contains advanced configurations for some services.
+#
+# You must copy it into `inventory/host_vars/` and rename it to the inventory
+# hostname set in `hosts` file.  For example, if the inventory hostname is:
+#
+# user@lemmy.example.com
+#
+# then the file must be named:
+#
+# user@lemmy.example.com.yml
+#
+# Remember the `.yml` extension!
+##############################################################################
+
+##### Pictrs Object Storage Config
+# Values for these may be found in the pict.rs documentation:
+# https://git.asonix.dog/asonix/pict-rs/src/branch/main#user-content-filesystem-to-object-storage-migration
+#####
+
+## Enable storage type
+#use_object_storage: yes
+
+## Configure Object Storage
+#pictrs_store_endpoint: https://object-storage-endpoint
+#pictrs_store_bucket: bucket-name
+#pictrs_store_region: region
+## Don't quote this
+#pictrs_store_use_path_style: no
+#pictrs_store_access_key: access-key
+#pictrs_store_secret_key: secret-key
+
+#####

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -64,6 +64,16 @@ services:
       - PICTRS__MEDIA__GIF__MAX_HEIGHT=256
       - PICTRS__MEDIA__GIF__MAX_AREA=65536
       - PICTRS__MEDIA__GIF__MAX_FRAME_COUNT=400
+{% if use_object_storage %}
+      - PICTRS__STORE__TYPE=object_storage
+      - PICTRS__STORE__ENDPOINT={{ pictrs_store_endpoint }}
+      - PICTRS__STORE__BUCKET_NAME={{ pictrs_store_bucket }}
+      - PICTRS__STORE__REGION=region={{ pictrs_store_region }}
+      - PICTRS__STORE__USE_PATH_STYLE={{ pictrs_store_use_path_style | lower }}
+      - PICTRS__STORE__ACCESS_KEY={{ pictrs_store_access_key }}
+      - PICTRS__STORE__SECRET_KEY={{ pictrs_store_secret_key }}
+{% endif %}
+
     user: 991:991
     volumes:
       - ./volumes/pictrs:/mnt:Z


### PR DESCRIPTION
[Thank you for putting up with the spam from my previous PRs -- I fell into git history hell and couldn't figure how to get out of it]

---

This PR adds a feature flag to enable object storage for Pict.rs.

This PR uses the same additional host vars framework as [my other PR](https://github.com/LemmyNet/lemmy-ansible/pull/136).  Some changes from that PR are replicated here in the event the other PR is not accepted.

Known issue: I did not implement a method for migrating from file storage to object storage.  The consequence of this is whether or not object storage will be used *must* be decided before the first time the lemmy.yml playbook is executed.  It cannot be changed later without [manual intervention](https://git.asonix.dog/asonix/pict-rs/src/branch/main#user-content-filesystem-to-object-storage-migration).