### PR TITLE
configure debian docker apt repos

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -44,7 +44,7 @@
           - "virtualenv"
           - "python3-setuptools"
 
-    - name: Configure Docker apt repo before Jammy
+    - name: Configure Docker apt repo for Ubuntu < 22.04
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'
       block:
         - name: Add Docker GPG apt Key
@@ -56,17 +56,21 @@
             repo: deb https://download.docker.com/linux/ubuntu focal stable
             state: present
 
-    - name: Configure Docker apt repo on Jammy++
-      when: ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04'
+    # based on https://docs.docker.com/engine/install/debian/
+    # and https://docs.docker.com/engine/install/ubuntu/
+    # note that Debian and Ubuntu use the same key
+    - name: Configure Docker apt repo for Debian or Ubuntu >= 22.04
+      when: (ansible_distribution == 'Debian') or
+            (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
       block:
         - name: Download Docker GPG Key
           get_url:
-            url: https://download.docker.com/linux/ubuntu/gpg
+            url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
             dest: /etc/apt/keyrings/docker.asc
             checksum: sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
-        - name: Add Docker to apt
+        - name: Add Docker apt repo
           apt_repository:
-            repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+            repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
             state: present
 
     - name: Update apt and install docker-ce

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -61,7 +61,7 @@
     # note that Debian and Ubuntu use the same key
     - name: Configure Docker apt repo for Debian or Ubuntu >= 22.04
       when: (ansible_distribution == 'Debian') or
-            (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
       block:
         - name: Download Docker GPG Key
           get_url:


### PR DESCRIPTION
Fixes https://github.com/LemmyNet/lemmy-ansible/issues/134

Tested on Debian Bookworm 12 and Ubuntu 22.04 and 23.04. It *should* configure apt on Debian Bullseye 11 as well, according to https://docs.docker.com/engine/install/debian/