### PR TITLE
Get dpkg-formatted arch and use it for docker apt repo

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -57,6 +57,8 @@
             state: present
 
     - name: Get architecture using dpkg
+      when: (ansible_distribution == 'Debian') or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
       command: dpkg --print-architecture
       register: dpkg_output
       changed_when: false
@@ -71,11 +73,11 @@
         - name: Download Docker GPG Key
           get_url:
             url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
-            dest: /etc/apt/keyrings/docker.asc
+            dest: /etc/apt/trusted.gpg.d/docker.asc
             checksum: sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
         - name: Add Docker apt repo
           apt_repository:
-            repo: "deb [arch={{ dpkg_output.stdout }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+            repo: "deb [arch={{ dpkg_output.stdout }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
             state: present
 
     - name: Update apt and install docker-ce

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -56,6 +56,11 @@
             repo: deb https://download.docker.com/linux/ubuntu focal stable
             state: present
 
+    - name: Get architecture using dpkg
+      command: dpkg --print-architecture
+      register: dpkg_output
+      changed_when: false
+
     # based on https://docs.docker.com/engine/install/debian/
     # and https://docs.docker.com/engine/install/ubuntu/
     # note that Debian and Ubuntu use the same key
@@ -70,7 +75,7 @@
             checksum: sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
         - name: Add Docker apt repo
           apt_repository:
-            repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+            repo: "deb [arch={{ dpkg_output.stdout }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
             state: present
 
     - name: Update apt and install docker-ce


### PR DESCRIPTION
Should pass CI checks, tested against Jammy amd64/arm64. Ansible has no built-in facts that return the format that `apt`/`dpkg` is looking for (EX; `ansible_architecture`).

- Fixes #130
- Tested against amd64/arm64