### PR TITLE
Fix duplicate headers being sent by nginx

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -57,14 +57,9 @@ http {
 
         gzip on;
         gzip_types text/css application/javascript image/svg+xml;
-        gzip_vary on;
 
         # Upload limit, relevant for pictrs
         client_max_body_size 20M;
-
-        add_header X-Frame-Options SAMEORIGIN;
-        add_header X-Content-Type-Options nosniff;
-        add_header X-XSS-Protection "1; mode=block";
 
         # Send actual client IP upstream
         proxy_set_header X-Real-IP $remote_addr;

--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -55,9 +55,6 @@ http {
         server_name localhost;
         server_tokens off;
 
-        gzip on;
-        gzip_types text/css application/javascript image/svg+xml;
-
         # Upload limit, relevant for pictrs
         client_max_body_size 20M;
 


### PR DESCRIPTION
The only noteworthy change is I opted to send `X-Frame-Options: DENY` instead of `X-Frame-Options: SAMEORIGIN` as it's more restrictive, and I don't believe Lemmy needs anything more lax. It is also in line with the documentation instructions from [install from scratch](https://join-lemmy.org/docs/administration/from_scratch.html#configure-reverse-proxy-and-tls), which uses the [nginx.conf](https://raw.githubusercontent.com/LemmyNet/lemmy-ansible/main/templates/nginx.conf) from this repository, which uses `X-Frame-Options: DENY`.

**Before**
```
vary: Accept-Encoding
vary: Accept-Encoding
x-content-type-options: nosniff
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
x-frame-options: DENY
```

**After**
```
vary: Accept-Encoding
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
x-frame-options: DENY
```

- Internal/external nginx were sending duplicate headers, removed from internal
- Opted X-Frame-Options DENY as default
- Fixes #143