### PR TITLE
Remove reliance on `pip` module 

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -80,7 +80,7 @@
             repo: "deb [arch={{ dpkg_output.stdout }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
             state: present
 
-    - name: Install Docker and docker-compose
+    - name: Install docker-ce and docker-compose
       apt:
         name:
           - docker-ce

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -80,18 +80,13 @@
             repo: "deb [arch={{ dpkg_output.stdout }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
             state: present
 
-    - name: Update apt and install docker-ce
+    - name: Install Docker and docker-compose
       apt:
-        name: docker-ce
-        state: latest
-        update_cache: true
-
-    - name: Install Docker Module and docker-compose for Python
-      pip:
         name:
-          - docker
+          - docker-ce
           - docker-compose
         state: latest
+        update_cache: true
 
     - name: copy docker config
       copy: src='../files/docker-daemon.json' dest='/etc/docker/daemon.json' mode='0644'


### PR DESCRIPTION
The reliance on the `ansible.builtin.pip` module caused Debian-based systems issues (#152). There are relevant packages in the default repositories of Debian 11, Debian 12, >=Ubuntu 22.04 LTS/they were redundant. As such, I've removed that portion of the playbook to use `apt`. 

After glancing at the repositories for these distributions, I realized that we probably don't need to use the Docker Community Edition and can use what's in the repositories safely. That will be another PR where we clean things up a bit, though :).

I've tested the changes against the targets mentioned above. If someone from #152 can confirm the fix, that'd be fantastic!