### PR TITLE
Fix incorrect/inconsistent usage of `proxy_set_header` 

### DIFF
--- a/files/proxy_params
+++ b/files/proxy_params
@@ -1,0 +1,4 @@
+proxy_set_header Host $http_host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -157,6 +157,16 @@
         - configs
         - postgresql
 
+    - name: Distribute nginx proxy_params configuration
+      ansible.builtin.copy:
+        src: files/proxy_params
+        dest: "{{ lemmy_base_dir }}/{{ domain }}/proxy_params"
+        owner: root
+        group: root
+        mode: "0644"
+      tags:
+        - nginx
+
     - name: Distribute nginx site templates
       ansible.builtin.template:
         src: "{{ item.src }}"

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -113,6 +113,14 @@
         - set_fact:
             lemmy_port: "{{ 32767 |random(start=1024) }}"
 
+        - name: Distribute nginx proxy_params configuration
+          ansible.builtin.copy:
+            src: files/proxy_params
+            dest: "{{ lemmy_base_dir }}/{{ domain }}/proxy_params"
+            owner: root
+            group: root
+            mode: "0644"
+
         - name: add template files
           template:
             src: "{{item.src}}"

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "{{ lemmy_port }}:8536"
     volumes:
       - ./nginx_internal.conf:/etc/nginx/nginx.conf:ro,Z
+      - ./proxy_params:/etc/nginx/proxy_params:ro,Z
     restart: always
     logging: *default-logging
     depends_on:

--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -59,9 +59,7 @@ http {
         client_max_body_size 20M;
 
         # Send actual client IP upstream
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        include proxy_params;
 
         # frontend general requests
         location / {
@@ -79,6 +77,7 @@ http {
             proxy_pass "http://lemmy";
 
             # proxy common stuff
+            include proxy_params;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";

--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -76,11 +76,8 @@ http {
         location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
             proxy_pass "http://lemmy";
 
-            # proxy common stuff
+            # Send actual client IP upstream
             include proxy_params;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
         }
     }
 }


### PR DESCRIPTION
Fixes the issue described in #155.

Tested against the normal spread of targets (Debian 11,12,Ubuntu 22.04 LTS, AL9/RHEL9). 

- Distribute proxy_params to nginx VM, include it as necessary in config
- Resolves #155