### PR TITLE
Fix nginx connect 111 error.

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -21,29 +21,19 @@ http {
     # Learn more about nginx maps here http://nginx.org/en/docs/http/ngx_http_map_module.html
     map "$request_method:$http_accept" $proxpass {
         # If no explicit matches exists below, send traffic to lemmy-ui
-        default "http://lemmy-ui";
+        default "http://lemmy-ui:1234";
 
         # GET/HEAD requests that accepts ActivityPub or Linked Data JSON should go to lemmy.
         #
         # These requests are used by Mastodon and other fediverse instances to look up profile information,
         # discover site information and so on.
-        "~^(?:GET|HEAD):.*?application\/(?:activity|ld)\+json" "http://lemmy";
+        "~^(?:GET|HEAD):.*?application\/(?:activity|ld)\+json" "http://lemmy:8536";
 
         # All non-GET/HEAD requests should go to lemmy
         #
         # Rather than calling out POST, PUT, DELETE, PATCH, CONNECT and all the verbs manually
         # we simply negate the GET|HEAD pattern from above and accept all possibly $http_accept values
-        "~^(?!(GET|HEAD)).*:" "http://lemmy";
-    }
-
-    upstream lemmy {
-        # this needs to map to the lemmy (server) docker service hostname
-        server "lemmy:8536";
-    }
-
-    upstream lemmy-ui {
-        # this needs to map to the lemmy-ui docker service hostname
-        server "lemmy-ui:1234";
+        "~^(?!(GET|HEAD)).*:" "http://lemmy:8536";
     }
 
     server {
@@ -69,12 +59,12 @@ http {
 
         # security.txt
         location = /.well-known/security.txt {
-            proxy_pass "http://lemmy-ui";
+            proxy_pass "http://lemmy-ui:1234";
         }
 
         # backend
         location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
-            proxy_pass "http://lemmy";
+            proxy_pass "http://lemmy:8536";
 
             # Send actual client IP upstream
             include proxy_params;


### PR DESCRIPTION
On lemmy.ml , we've been periodically getting some unrecoverable errors with our internal nginx proxy. Only doing `sudo docker compose restart proxy` fixes it for a few hours.

Error: `connect() failed (111: Connection refused)`

Context and potential fix: https://stackoverflow.com/questions/51009692/docker-nginx-proxy-nginx-connect-failed-111-connection-refused-while-connec

I'm seeing if this will fix the issue now.