### PR TITLE
Fix ansible-lint warnings

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -10,3 +10,8 @@ pipeline:
       - ansible-playbook lemmy.yml --syntax-check
       - ansible-playbook lemmy-almalinux.yml --syntax-check
       - ansible-playbook uninstall.yml --syntax-check
+  ansible_lint:
+    image: alpine:3
+    commands:
+      - apk add ansible ansible-lint
+      - ansible-lint --warn-list experimental lemmy.yml lemmy-almalinux.yml uninstall.yml

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -1,16 +1,18 @@
 ---
-- hosts: all
+- name: Install Lemmy
+  hosts: all
   gather_facts: true
   pre_tasks:
     # This is not needed for this playbook as it predates its existence
     # But we're keeping it for funsies :)
-    - name: check lemmy_base_dir
+    - name: Check lemmy_base_dir
       ansible.builtin.fail:
         msg: "`lemmy_base_dir` is unset. if you are upgrading from an older version, add `lemmy_base_dir=/lemmy` to your inventory file."
       when: lemmy_base_dir is not defined
   handlers:
-    - name: reload nginx
+    - name: Reload nginx
       ansible.builtin.command: nginx -s reload
+      changed_when: true
   vars:
     lemmy_port: "{{ 32767 | random(start=1024) }}"
   tasks:
@@ -30,7 +32,7 @@
         mirrorlist: https://mirrors.almalinux.org/mirrorlist/$releasever/crb
         gpgcheck: true
         gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9
-        enabled: yes
+        enabled: true
       tags:
         - dependencies
 
@@ -72,12 +74,14 @@
         - http
         - https
       when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
+      changed_when: true
       tags:
         - firewalld
 
     - name: Reload firewalld
       ansible.builtin.command: firewall-cmd --reload
       when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
+      changed_when: true
       tags:
         - firewalld
 
@@ -96,6 +100,7 @@
         path: "{{ item.path }}"
         owner: "{{ item.owner }}"
         state: directory
+        mode: "0755"
       loop:
         - path: "{{ lemmy_base_dir }}/{{ domain }}/"
           owner: "root"
@@ -106,7 +111,7 @@
 
     - name: Set lemmy_port fact
       ansible.builtin.set_fact:
-        lemmy_port: "{{ 32767 |random(start=1024) }}"
+        lemmy_port: "{{ 32767 | random(start=1024) }}"
       tags:
         - always
 
@@ -123,8 +128,8 @@
           dest: "{{ lemmy_base_dir }}/{{ domain }}/nginx_internal.conf"
           mode: "0644"
       vars:
-        lemmy_docker_image: "docker.io/dessalines/lemmy:{{ lemmy_version | default( lookup('file', 'VERSION') )}}"
-        lemmy_docker_ui_image: "docker.io/dessalines/lemmy-ui:{{ lemmy_ui_version | default(lemmy_version | default(lookup('file', 'VERSION')))}}"
+        lemmy_docker_image: "docker.io/dessalines/lemmy:{{ lemmy_version | default(lookup('file', 'VERSION')) }}"
+        lemmy_docker_ui_image: "docker.io/dessalines/lemmy-ui:{{ lemmy_ui_version | default(lemmy_version | default(lookup('file', 'VERSION'))) }}"
       tags:
         - docker
         - podman
@@ -133,7 +138,7 @@
     # to ensure documentation is accurate
     - name: Add the config.hjson
       ansible.builtin.template:
-        #src: "templates/{{ domain }}/config.hjson"
+        # src: "templates/{{ domain }}/config.hjson"
         src: "inventory/host_vars/{{ domain }}/config.hjson"
         dest: "{{ lemmy_base_dir }}/{{ domain }}/lemmy.hjson"
         mode: "0600"
@@ -146,7 +151,7 @@
     # to ensure documentation is accurate
     - name: Add the customPostgresql.conf
       ansible.builtin.template:
-        #src: "files/{{ domain }}/customPostgresql.conf"
+        # src: "files/{{ domain }}/customPostgresql.conf"
         src: "inventory/host_vars/{{ domain }}/customPostgresql.conf"
         dest: "{{ lemmy_base_dir }}/{{ domain }}/customPostgresql.conf"
         mode: "0600"
@@ -180,31 +185,31 @@
         - nginx
 
     # TODO: Check if this is necessary with EL & podman
-    #- name: Copy docker config
-    #  ansible.builtin.copy:
-    #    src: "{{ ansible_playbook }}/files/docker-daemon.json"
-    #    dest: /etc/docker/daemon.json
-    #    mode: '0644'
+    # - name: Copy docker config
+    #   ansible.builtin.copy:
+    #     src: "{{ ansible_playbook }}/files/docker-daemon.json"
+    #     dest: /etc/docker/daemon.json
+    #     mode: '0644'
 
     # TODO: podman-compose should wrap this safely
     # TODO: This was an incorrect assumption, module uses docker python module, not cli
-    #- name: Run podman-compose
-    #  docker_compose:
-    #    project_src: "{{ lemmy_base_dir }}/{{ domain }}"
-    #    state: present
-    #    pull: yes
-    #    remove_orphans: yes
-    #  tags:
-    #    - docker
-    #    - docker_compose
-    #    - podman
-    #    - podman_compose
+    # - name: Run podman-compose
+    #   docker_compose:
+    #     project_src: "{{ lemmy_base_dir }}/{{ domain }}"
+    #     state: present
+    #     pull: yes
+    #     remove_orphans: yes
+    #   tags:
+    #     - docker
+    #     - docker_compose
+    #     - podman
+    #     - podman_compose
 
     - name: Start and enable podman service
       ansible.builtin.systemd:
         name: podman.service
         state: started
-        enabled: yes
+        enabled: true
       tags:
         - docker
         - podman
@@ -213,6 +218,7 @@
       ansible.builtin.command: podman-compose pull
       args:
         chdir: "{{ lemmy_base_dir }}/{{ domain }}"
+      changed_when: true
       tags:
         - docker
         - podman
@@ -221,6 +227,7 @@
       ansible.builtin.command: podman-compose up -d
       args:
         chdir: "{{ lemmy_base_dir }}/{{ domain }}"
+      changed_when: true
       tags:
         - docker
         - podman
@@ -239,7 +246,7 @@
       ansible.builtin.systemd:
         name: certbot-renew.timer
         state: started
-        enabled: yes
+        enabled: true
       tags:
         - certbot
         - ssl

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -1,35 +1,37 @@
 ---
-- hosts: all
+- name: Install Lemmy
+  hosts: all
 
   # Install python if required
   # https://www.josharcher.uk/code/ansible-python-connection-failure-ubuntu-server-1604/
-  gather_facts: False
+  gather_facts: false
   pre_tasks:
-    - name: check lemmy_base_dir
-      fail:
+    - name: Check lemmy_base_dir
+      ansible.builtin.fail:
         msg: "`lemmy_base_dir` is unset. if you are upgrading from an older version, add `lemmy_base_dir=/lemmy` to your inventory file."
       when: lemmy_base_dir is not defined
 
     - name: Install python for Ansible
       # python2-minimal instead of python-minimal for ubuntu 20.04 and up
-      raw: test -e /usr/bin/python || test -e /usr/bin/python3 || (apt -y update && apt install -y python3-minimal python3-setuptools)
+      ansible.builtin.raw: test -e /usr/bin/python || test -e /usr/bin/python3 || (apt -y update && apt install -y python3-minimal python3-setuptools)
       args:
         executable: /bin/bash
       register: output
       changed_when: output.stdout != ''
 
-    - setup: # gather facts
+    - name: Gather facts
+      ansible.builtin.setup:
 
   tasks:
     - name: Install aptitude
-      apt:
+      ansible.builtin.apt:
         name: aptitude
-        state: latest
+        state: present
         update_cache: true
 
-    - name: install dependencies
-      apt:
-        state: latest
+    - name: Install dependencies
+      ansible.builtin.apt:
+        state: present
         update_cache: true
         pkg:
           - "nginx"
@@ -48,18 +50,18 @@
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'
       block:
         - name: Add Docker GPG apt Key
-          apt_key:
+          ansible.builtin.apt_key:
             url: https://download.docker.com/linux/ubuntu/gpg
             state: present
         - name: Add Docker Repository
-          apt_repository:
+          ansible.builtin.apt_repository:
             repo: deb https://download.docker.com/linux/ubuntu focal stable
             state: present
 
     - name: Get architecture using dpkg
       when: (ansible_distribution == 'Debian') or
         (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
-      command: dpkg --print-architecture
+      ansible.builtin.command: dpkg --print-architecture
       register: dpkg_output
       changed_when: false
 
@@ -71,47 +73,56 @@
         (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
       block:
         - name: Download Docker GPG Key
-          get_url:
+          ansible.builtin.get_url:
             url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
             dest: /etc/apt/trusted.gpg.d/docker.asc
             checksum: sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
+            mode: "0644"
         - name: Add Docker apt repo
-          apt_repository:
-            repo: "deb [arch={{ dpkg_output.stdout }} signed-by=/etc/apt/trusted.gpg.d/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+          ansible.builtin.apt_repository:
+            repo: >-
+              deb [arch={{ dpkg_output.stdout }} signed-by=/etc/apt/trusted.gpg.d/docker.asc]
+              https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
             state: present
 
     - name: Install docker-ce and docker-compose
-      apt:
+      ansible.builtin.apt:
         name:
           - docker-ce
           - docker-compose
-        state: latest
+        state: present
         update_cache: true
 
-    - name: copy docker config
-      copy: src='../files/docker-daemon.json' dest='/etc/docker/daemon.json' mode='0644'
+    - name: Copy docker config
+      ansible.builtin.copy:
+        src: ../files/docker-daemon.json # noqa: no-relative-paths
+        dest: /etc/docker/daemon.json
+        mode: "0644"
 
-    - name: request initial letsencrypt certificate
-      command: certbot certonly --nginx --agree-tos --cert-name '{{ domain }}' -d '{{ domain }}' -m '{{ letsencrypt_contact_email }}'
+    - name: Request initial letsencrypt certificate
+      ansible.builtin.command: certbot certonly --nginx --agree-tos --cert-name '{{ domain }}' -d '{{ domain }}' -m '{{ letsencrypt_contact_email }}'
       args:
-        creates: "/etc/letsencrypt/live/{{domain}}/privkey.pem"
+        creates: "/etc/letsencrypt/live/{{ domain }}/privkey.pem"
 
-    - name: create lemmy folder
-      file:
-        path: "{{item.path}}"
-        owner: "{{item.owner}}"
+    - name: Create lemmy folder
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        owner: "{{ item.owner }}"
         state: directory
+        mode: "0755"
       with_items:
-        - path: "{{lemmy_base_dir}}/{{domain}}/"
+        - path: "{{ lemmy_base_dir }}/{{ domain }}/"
           owner: "root"
-        - path: "{{lemmy_base_dir}}/{{domain}}/volumes/"
+        - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/"
           owner: "root"
-        - path: "{{lemmy_base_dir}}/{{domain}}/volumes/pictrs/"
+        - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/pictrs/"
           owner: "991"
 
-    - block:
-        - set_fact:
-            lemmy_port: "{{ 32767 |random(start=1024) }}"
+    - name: Deploy configuration files
+      block:
+        - name: Generate random port for lemmy service
+          ansible.builtin.set_fact:
+            lemmy_port: "{{ 32767 | random(start=1024) }}"
 
         - name: Distribute nginx proxy_params configuration
           ansible.builtin.copy:
@@ -121,63 +132,64 @@
             group: root
             mode: "0644"
 
-        - name: add template files
-          template:
-            src: "{{item.src}}"
-            dest: "{{item.dest}}"
-            mode: "{{item.mode}}"
+        - name: Add template files
+          ansible.builtin.template:
+            src: "{{ item.src }}"
+            dest: "{{ item.dest }}"
+            mode: "{{ item.mode }}"
           with_items:
             - src: "templates/docker-compose.yml"
-              dest: "{{lemmy_base_dir}}/{{domain}}/docker-compose.yml"
+              dest: "{{ lemmy_base_dir }}/{{ domain }}/docker-compose.yml"
               mode: "0600"
             - src: "templates/nginx_internal.conf"
-              dest: "{{lemmy_base_dir}}/{{domain}}/nginx_internal.conf"
+              dest: "{{ lemmy_base_dir }}/{{ domain }}/nginx_internal.conf"
               mode: "0644"
             - src: "templates/nginx.conf"
-              dest: "/etc/nginx/sites-available/{{domain}}.conf"
+              dest: "/etc/nginx/sites-available/{{ domain }}.conf"
               mode: "0644"
           vars:
-            lemmy_docker_image: "dessalines/lemmy:{{ lemmy_version | default( lookup('file', 'VERSION') )}}"
-            lemmy_docker_ui_image: "dessalines/lemmy-ui:{{ lemmy_ui_version | default(lemmy_version | default(lookup('file', 'VERSION')))}}"
+            lemmy_docker_image: "dessalines/lemmy:{{ lemmy_version | default(lookup('file', 'VERSION')) }}"
+            lemmy_docker_ui_image: "dessalines/lemmy-ui:{{ lemmy_ui_version | default(lemmy_version | default(lookup('file', 'VERSION'))) }}"
 
-        - block:
-            - name: gather stats on site enabled config
-              stat:
-                path: "/etc/nginx/sites-enabled/{{domain}}.conf"
+        - name: Set up nginx sites-enabled symlink
+          block:
+            - name: Gather stats on site enabled config
+              ansible.builtin.stat:
+                path: "/etc/nginx/sites-enabled/{{ domain }}.conf"
               register: reg_enabled
 
-            - name: remove if regular file (legacy) instead of symlink
-              file:
-                path: "/etc/nginx/sites-enabled/{{domain}}.conf"
+            - name: Remove if regular file (legacy) instead of symlink
+              ansible.builtin.file:
+                path: "/etc/nginx/sites-enabled/{{ domain }}.conf"
                 state: absent
               when: reg_enabled.stat.exists and reg_enabled.stat.isreg
 
-            - name: enable nginx site
-              file:
-                src: "../sites-available/{{domain}}.conf"
-                dest: "/etc/nginx/sites-enabled/{{domain}}.conf"
+            - name: Enable nginx site
+              ansible.builtin.file:
+                src: "../sites-available/{{ domain }}.conf"
+                dest: "/etc/nginx/sites-enabled/{{ domain }}.conf"
                 state: link
 
-        - name: add the config.hjson
-          template:
-            src: "inventory/host_vars/{{domain}}/config.hjson"
-            dest: "{{lemmy_base_dir}}/{{domain}}/lemmy.hjson"
+        - name: Add the config.hjson
+          ansible.builtin.template:
+            src: "inventory/host_vars/{{ domain }}/config.hjson"
+            dest: "{{ lemmy_base_dir }}/{{ domain }}/lemmy.hjson"
             mode: "0600"
             owner: "1000"
             group: "1000"
 
-        - name: add the customPostgresql.conf
-          template:
-            src: "inventory/host_vars/{{domain}}/customPostgresql.conf"
-            dest: "{{lemmy_base_dir}}/{{domain}}/customPostgresql.conf"
+        - name: Add the customPostgresql.conf
+          ansible.builtin.template:
+            src: "inventory/host_vars/{{ domain }}/customPostgresql.conf"
+            dest: "{{ lemmy_base_dir }}/{{ domain }}/customPostgresql.conf"
             mode: "0600"
             owner: "1000"
             group: "1000"
 
-    - name: enable and start docker service
-      systemd:
+    - name: Enable and start docker service
+      ansible.builtin.systemd:
         name: docker
-        enabled: yes
+        enabled: true
         state: started
 
     # - name: Change the working directory to /opt
@@ -187,18 +199,19 @@
     #     register: shell_output
     # - debug: var=shell_output
 
-    - name: start docker-compose
-      docker_compose:
-        project_src: "{{lemmy_base_dir}}/{{domain}}"
+    - name: Start docker-compose
+      community.docker.docker_compose:
+        project_src: "{{ lemmy_base_dir }}/{{ domain }}"
         state: present
-        pull: yes
-        remove_orphans: yes
+        pull: true
+        remove_orphans: true
 
-    - name: reload nginx with new config
-      shell: nginx -s reload
+    - name: Reload nginx with new config
+      ansible.builtin.command: nginx -s reload
+      changed_when: true
 
-    - name: certbot renewal cronjob
-      cron:
+    - name: Certbot renewal cronjob
+      ansible.builtin.cron:
         special_time: daily
         name: certbot-renew-lemmy
         user: root

--- a/uninstall.yml
+++ b/uninstall.yml
@@ -1,49 +1,52 @@
 ---
-- hosts: all
+- name: Uninstall Lemmy
+  hosts: all
 
   vars_prompt:
     - name: confirm_uninstall
       prompt: "Do you really want to uninstall Lemmy? This will delete all data and can not be reverted [yes/no]"
-      private: no
+      private: false
 
     - name: delete_certs
       prompt: "Delete certificates? Select 'no' if you want to reinstall Lemmy [yes/no]"
-      private: no
+      private: false
 
     - name: stop_disable_nginx
       prompt: "Do you want to stop/disable nginx? [yes/no]"
-      private: no
+      private: false
 
     - name: stop_disable_docker_podman
       prompt: "Do you want to stop/disable Docker/podman? [yes/no]"
-      private: no
+      private: false
 
   tasks:
-    - name: end play if no confirmation was given
-      debug:
+    - name: Inform about cancellation if no confirmation was given
+      ansible.builtin.debug:
         msg: "Uninstall cancelled, doing nothing"
-      when: not confirm_uninstall|bool
+      when: not confirm_uninstall | bool
 
-    - meta: end_play
-      when: not confirm_uninstall|bool
+    - name: End play if no confirmation was given
+      ansible.builtin.meta: end_play
+      when: not confirm_uninstall | bool
 
-    # Ubuntu specific uninstallation steps
-    - block:
-        - name: stop docker-compose
-          docker_compose:
-            project_src: "{{lemmy_base_dir}}/{{domain}}"
+    - name: Run Ubuntu specific uninstallation steps
+      when: ansible_distribution == "Ubuntu"
+      block:
+        - name: Stop docker-compose
+          community.docker.docker_compose:
+            project_src: "{{ lemmy_base_dir }}/{{ domain }}"
             state: absent
 
-        - name: delete data
-          file:
-            path: "{{item.path}}"
+        - name: Delete data
+          ansible.builtin.file:
+            path: "{{ item.path }}"
             state: absent
           with_items:
-            - path: "{{lemmy_base_dir}}/{{domain}}"
-            - path: "/etc/nginx/sites-enabled/{{domain}}.conf"
+            - path: "{{ lemmy_base_dir }}/{{ domain }}"
+            - path: "/etc/nginx/sites-enabled/{{ domain }}.conf"
 
-        - name: remove certbot cronjob
-          cron:
+        - name: Remove certbot cronjob
+          ansible.builtin.cron:
             name: certbot-renew-lemmy
             state: absent
 
@@ -51,44 +54,44 @@
           ansible.builtin.systemd:
             name: docker.service
             state: stopped
-            enabled: no
-          when: stop_disable_docker_podman|bool
-      when: ansible_distribution == "Ubuntu"
+            enabled: false
+          when: stop_disable_docker_podman | bool
 
-    # EL specific uninstallation steps
-    - block:
+    - name: Run EL specific uninstallation steps
+      when:
+        - ansible_distribution in ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky']
+        - ansible_distribution_major_version | int >= 9
+      block:
         - name: Stop and remove containers
           ansible.builtin.command: podman-compose down
           args:
             chdir: "{{ lemmy_base_dir }}/{{ domain }}"
+          changed_when: true
 
         - name: Delete Lemmy data
           ansible.builtin.file:
             path: "{{ item.path }}"
             state: absent
           loop:
-            - path: "{{lemmy_base_dir}}/{{ domain }}"
+            - path: "{{ lemmy_base_dir }}/{{ domain }}"
             - path: "/etc/nginx/conf.d/{{ domain }}.conf"
 
         - name: Stop and disable certbot-renew.timer
           ansible.builtin.systemd:
             name: certbot-renew.timer
             state: stopped
-            enabled: no
+            enabled: false
 
         - name: Stop and disable podman
           ansible.builtin.systemd:
             name: podman.service
             state: stopped
-            enabled: no
-          when: stop_disable_docker_podman|bool
-      when:
-        - ansible_distribution in ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky']
-        - ansible_distribution_major_version | int >= 9
+            enabled: false
+          when: stop_disable_docker_podman | bool
 
     - name: Stop and disable nginx
       ansible.builtin.systemd:
         name: nginx.service
         state: stopped
-        enabled: no
-      when: stop_disable_nginx|bool
+        enabled: false
+      when: stop_disable_nginx | bool


### PR DESCRIPTION
- add ansible-lint check to CI
- reformat playbooks to conform to strict ansible-lint checks
- set explicit modes for all files and directories created in playbook
- only ensure presence, not latest for packages installed by the playbook

## Logic changes in this PR

### `lemmy-almalinux.yml`

- `{{ lemmy_base_dir }}/{{ domain }}` and directories within will now be created with `chmod 0755`.
This was previously left to the system's default umask, which typically results in `0755` for directories.
Related linter rule: [risky-file-permissions](https://ansible.readthedocs.io/projects/lint/rules/risky-file-permissions/)

### `lemmy.yml`

- Docker GPG key will now be downloaded with `chmod 0644`.
This was previously left to the system's default umask, which typically results in `0644` for files.
Related linter rule: [risky-file-permissions](https://ansible.readthedocs.io/projects/lint/rules/risky-file-permissions/)
- Package installations will now only ensure presence of packages instead of ensuring the latest version of the package is installed.
I'm not sure which is the desired behavior here, I'd expect to have a separate dedicated "full update" task if it's desired to also perform a system update at this stage.
For example, when updating docker to a newer version, this will also restart the docker service and in turn all containers.
Related linter rule: [package-latest](https://ansible.readthedocs.io/projects/lint/rules/package-latest/)