### PR TITLE
Fix path to docker-daemon.json

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -99,7 +99,7 @@
 
     - name: Copy docker config
       ansible.builtin.copy:
-        src: ../files/docker-daemon.json # noqa: no-relative-paths
+        src: files/docker-daemon.json
         dest: /etc/docker/daemon.json
         mode: "0644"
 


### PR DESCRIPTION
This currently only works because [ansible pathing](https://docs.ansible.com/ansible/latest/playbook_guide/playbook_pathing.html). Will also remove the need to `noqa` ansible-lint for `no-relative-paths`.