### PR TITLE
Make firewalld operations idempotent

### DIFF
--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -114,7 +114,6 @@
         - http
         - https
       when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
-      notify: Reload firewalld
       tags:
         - firewalld
 

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -98,14 +98,17 @@
       tags:
         - firewalld
 
-    # TODO: Use ansible.posix.firewalld
     - name: Allow http/httpd traffic to public zone in firewalld
-      ansible.builtin.command: "firewall-cmd --zone=public --add-service={{ item }} --perm"
+      ansible.posix.firewalld:
+        service: "{{ item }}"
+        state: enabled
+        zone: public
+        permanent: true
+        immediate: true
       loop:
         - http
         - https
       when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
-      changed_when: true
       tags:
         - firewalld
 

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -44,6 +44,11 @@
       ansible.builtin.systemd:
         name: nginx
         state: reloaded
+
+    - name: Reload firewalld
+      ansible.builtin.systemd:
+        name: firewalld
+        state: reloaded
   vars:
     lemmy_port: "{{ 32767 | random(start=1024) }}"
   tasks:
@@ -109,14 +114,7 @@
         - http
         - https
       when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
-      tags:
-        - firewalld
-
-    - name: Reload firewalld
-      ansible.builtin.systemd:
-        name: firewalld
-        state: reloaded
-      when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
+      notify: Reload firewalld
       tags:
         - firewalld
 

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -113,9 +113,10 @@
         - firewalld
 
     - name: Reload firewalld
-      ansible.builtin.command: firewall-cmd --reload
+      ansible.builtin.systemd:
+        name: firewalld
+        state: reloaded
       when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
-      changed_when: true
       tags:
         - firewalld
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.posix


### PR DESCRIPTION
I haven't worked much with `ansible.posix.firewalld` before, so let me know if there's something which needs changing. Think I've translated it over correctly though.