### PR TITLE
feat: pictrs-safety

### DIFF
--- a/examples/hosts
+++ b/examples/hosts
@@ -9,7 +9,8 @@
 #                                if you are upgrading from a previous version, set this to `/lemmy`
 # - `lemmy_version`: <Optional> The back end version.
 # - `lemmy_ui_version`: <Optional> overrides the front end version.
-example.com  ansible_user=root domain=example.com  letsencrypt_contact_email=your@email.com  lemmy_base_dir=/srv/lemmy
+# - `use_pictrs_safety`: <Optional> If true, a docker container for pictrs-safety will be deployed and pict-rs will be configured to validate images through it. You will also need to set up a fedi-safety worker to validate the images.
+example.com  ansible_user=root domain=example.com  letsencrypt_contact_email=your@email.com  lemmy_base_dir=/srv/lemmy pictrs_safety=false
 
 [all:vars]
 ansible_connection=ssh

--- a/examples/hosts
+++ b/examples/hosts
@@ -9,7 +9,7 @@
 #                                if you are upgrading from a previous version, set this to `/lemmy`
 # - `lemmy_version`: <Optional> The back end version.
 # - `lemmy_ui_version`: <Optional> overrides the front end version.
-# - `use_pictrs_safety`: <Optional> If true, a docker container for pictrs-safety will be deployed and pict-rs will be configured to validate images through it. You will also need to set up a fedi-safety worker to validate the images.
+# - `pictrs_safety`: <Optional> If true, a docker container for pictrs-safety will be deployed and pict-rs will be configured to validate images through it. You will also need to set up a fedi-safety worker to validate the images.
 example.com  ansible_user=root domain=example.com  letsencrypt_contact_email=your@email.com  lemmy_base_dir=/srv/lemmy pictrs_safety=false
 
 [all:vars]

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -35,3 +35,12 @@ lemmyui_env_vars:
 
 postfix_env_vars:
   - POSTFIX_myhostname: "{{ domain }}"
+
+pictrs_safety_env_vars:
+  # Use this in your fedi-safety to allow your worker to authenticate to pictrs-safety
+  - FEDIVERSE_SAFETY_WORKER_AUTH: "{{ lookup('password', 'inventory/host_vars/{{domain}}/passwords/pictrs_safety_worker_auth.psk chars=ascii_letters,digits length=15') }}"
+  - FEDIVERSE_SAFETY_IMGDIR: "/tmp/images"
+  - USE_SQLITE: 1
+  - secret_key: "{{ lookup('password', 'inventory/host_vars/{{domain}}/passwords/pictrs_safety_secret.psk chars=ascii_letters,digits length=80') }}"
+  - SCAN_BYPASS_THRESHOLD: 10
+  - MISSING_WORKER_THRESHOLD: 5

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -1,4 +1,7 @@
-postgres_password: "{{ lookup('password', 'inventory/host_vars/{{domain}}/passwords/postgres.psk chars=ascii_letters,digits') }}"
+postgres_password: "{{ lookup('password', 'inventory/host_vars/{{ domain }}/passwords/postgres.psk chars=ascii_letters,digits') }}"
+# Next two only relevant if pictrs_safety == True
+pictrs_safety_worker_auth: "{{ lookup('password', 'inventory/host_vars/{{ domain }}/passwords/pictrs_safety_worker_auth.psk chars=ascii_letters,digits length=15') }}"
+pictrs_safety_secret: "{{ lookup('password', 'inventory/host_vars/{{ domain }}/passwords/pictrs_safety_secret.psk chars=ascii_letters,digits length=80') }}"
 
 # You can set any pict-rs environmental variables here. They will populate the templates/docker-compose.yml file.
 # https://git.asonix.dog/asonix/pict-rs
@@ -38,9 +41,9 @@ postfix_env_vars:
 
 pictrs_safety_env_vars:
   # Use this in your fedi-safety to allow your worker to authenticate to pictrs-safety
-  - FEDIVERSE_SAFETY_WORKER_AUTH: "{{ lookup('password', 'inventory/host_vars/{{domain}}/passwords/pictrs_safety_worker_auth.psk chars=ascii_letters,digits length=15') }}"
+  - FEDIVERSE_SAFETY_WORKER_AUTH: "{{ pictrs_safety_worker_auth }}"
   - FEDIVERSE_SAFETY_IMGDIR: "/tmp/images"
   - USE_SQLITE: 1
-  - secret_key: "{{ lookup('password', 'inventory/host_vars/{{domain}}/passwords/pictrs_safety_secret.psk chars=ascii_letters,digits length=80') }}"
+  - secret_key: "{{ pictrs_safety_secret }}"
   - SCAN_BYPASS_THRESHOLD: 10
   - MISSING_WORKER_THRESHOLD: 5

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -118,7 +118,7 @@ services:
 
 {% if pictrs_safety is defined and pictrs_safety|bool == true %}
   pictrs-safety:
-    image: ghcr.io/db0/pictrs-safety:main
+    image: ghcr.io/db0/pictrs-safety:v1.2.2
     hostname: "pictrs-safety"
     networks:
       - lemmyinternal

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     logging: *default-logging
 
   pictrs:
-    image: docker.io/asonix/pictrs:0.4.0
+    image: docker.io/asonix/pictrs:0.4.3
     # this needs to match the pictrs url in lemmy.hjson
     hostname: pictrs
     # we can set options to pictrs like this, here we set max. image size and forced format for conversion
@@ -72,6 +72,9 @@ services:
       - {{ key }}={{ value }}
 {% endfor %}
 {% endfor %}
+{% endif %}
+{% if pictrs_safety is defined and pictrs_safety|bool == true %}
+      - PICTRS__MEDIA__EXTERNAL_VALIDATION=http://{{ domain }}:14051/api/v1/scan/IPADDR
 {% endif %}
     user: 991:991
     volumes:
@@ -112,3 +115,29 @@ services:
 {% endif %}
     restart: "always"
     logging: *default-logging
+
+{% if pictrs_safety is defined and pictrs_safety|bool == true %}
+  pictrs-safety:
+    image: ghcr.io/db0/pictrs-safety:main
+    hostname: "pictrs-safety"
+    networks:
+      - lemmyinternal
+      - lemmyexternalproxy
+    environment:
+{% if pictrs_safety_env_vars is defined and pictrs_safety_env_vars|length > 0 %}
+{% for item in pictrs_safety_env_vars %}
+{% for key, value in item.items() %}
+      - {{ key }}={{ value }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+    ports:
+      - "14051:14051"
+    expose:
+      - '14051'
+    user: 991:991
+    restart: always
+    logging: *default-logging
+    depends_on:
+      - pictrs
+{% endif %}

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -119,10 +119,7 @@ services:
 {% if pictrs_safety is defined and pictrs_safety|bool == true %}
   pictrs-safety:
     image: ghcr.io/db0/pictrs-safety:v1.2.2
-    hostname: "pictrs-safety"
-    networks:
-      - lemmyinternal
-      - lemmyexternalproxy
+    hostname: pictrs-safety
     environment:
 {% if pictrs_safety_env_vars is defined and pictrs_safety_env_vars|length > 0 %}
 {% for item in pictrs_safety_env_vars %}
@@ -133,8 +130,6 @@ services:
 {% endif %}
     ports:
       - "14051:14051"
-    expose:
-      - '14051'
     user: 991:991
     restart: always
     logging: *default-logging

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,9 +1,9 @@
-limit_req_zone $binary_remote_addr zone={{domain}}_ratelimit:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone={{ domain }}_ratelimit:10m rate=1r/s;
 
 server {
     listen 80;
     listen [::]:80;
-    server_name {{domain}};
+    server_name {{ domain }};
     # Hide nginx version
     server_tokens off;
     location /.well-known/acme-challenge/ {
@@ -17,10 +17,10 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name {{domain}};
+    server_name {{ domain }};
 
-    ssl_certificate /etc/letsencrypt/live/{{domain}}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/{{domain}}/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
 
 
     ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
Adds inventory variable to enable picts-safety

pictrs gets an extra conditional for a new variable `PICTRS__MEDIA__EXTERNAL_VALIDATION` to connect the validation to pictrs-safety. 

I used `{{ domain }} for it, as I don't know how otherwise to tell pictrs which IP to connect. Feel free to adjust to use some internal IP. My docker knowledge is very superficial.

Likewise, the pictrs-safety port is supposed to be exposed to the internet to allow workers to connect to it. 

Currently I'm using the `:main` version as I'm having trouble pushing versioned docker images to ghcr.io. I'm trying to figure that out.