### PR TITLE
Add vars.yml to woodpecker pipeline

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,7 +2,7 @@ pipeline:
   prettier_markdown_check:
     image: tmknom/prettier
     commands:
-      - prettier -c "*.md" "*.yml"
+      - prettier -c "*.md" "*.yml" "examples/vars.yml"
   check_ansible_format:
     image: alpine:3
     commands:
@@ -14,4 +14,4 @@ pipeline:
     image: alpine:3
     commands:
       - apk add ansible ansible-lint
-      - ansible-lint --warn-list experimental lemmy.yml lemmy-almalinux.yml uninstall.yml
+      - ansible-lint --warn-list experimental lemmy.yml lemmy-almalinux.yml uninstall.yml examples/vars.yml

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -12,11 +12,11 @@ pictrs_env_vars:
   - PICTRS_OPENTELEMETRY_URL: http://otel:4137
   - RUST_LOG: debug
   - RUST_BACKTRACE: full
-#  - PICTRS__STORE__TYPE: object_storage 
+#  - PICTRS__STORE__TYPE: object_storage
 #  - PICTRS__STORE__ENDPOINT: '<S3 endpoint>'
 #  - PICTRS__STORE__BUCKET_NAME: '<bucket name>'
 #  - PICTRS__STORE__REGION: '<region>'
-#  - PICTRS__STORE__USE_PATH_STYLE: false 
+#  - PICTRS__STORE__USE_PATH_STYLE: false
 #  - PICTRS__STORE__ACCESS_KEY: '<access key>'
 #  - PICTRS__STORE__SECRET_KEY: '<secret key>'
 


### PR DESCRIPTION
Run `ansible-lint` and `prettier` against `examples/vars.yml`. 

We could just run `prettier` on all `*.yml` if we wanted to instead.