### PR TITLE
fix: Removal of forced become

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,3 @@ inventory = inventory
 
 [ssh_connection]
 pipelining = True
-
-[privilege_escalation]
-become = True


### PR DESCRIPTION
# Issue

Now that we have a `delegate: localhost` having this line in our config forces sudo on localhost. 

# Solution

Remove this line so it is optional if people want to use `--become` in their deployments. 
Our readme already has `--become` as this is also redundant
