### PR TITLE
feat: Version 1.2.0 documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ To run this ansible playbook, you need to:
 
 ## Install
 
-1. Clone this repo:
+1. Clone this repo & checkout latest tag
 
    ```
    git clone https://github.com/LemmyNet/lemmy-ansible.git
    cd lemmy-ansible
+   git checkout $(git describe --tags)
    ```
 
 2. Make a directory to hold your config:
@@ -72,12 +73,28 @@ To run this ansible playbook, you need to:
 
 ## Upgrading
 
-- Run `git pull`
-- Check out the [Lemmy Releases Changelog](https://github.com/LemmyNet/lemmy/blob/main/RELEASES.md) to see if there are any config changes with the releases since your last.
+Since version `1.1.0` we no longer default to using `main` but use tags to make sure deployments are versioned.
+With every new release all migration steps shall be written below so make sure you check out the [Lemmy Releases Changelog](https://github.com/LemmyNet/lemmy/blob/main/RELEASES.md) to see if there are any config changes with the releases since your last.
+
+### Upgrading to 1.2.0 (Lemmy 0.18.5)
+
+Major changes:
+
+- All variables are not under a singular file so you will not need to modify anything: `inventory/host_vars/{{ domain }}/vars.yml`
+- `--become` is now optional instead of forced on
+
+#### Steps
+
+- Run `git pull && git checkout 1.2.0`
 - When upgrading from older versions of these playbooks, you will need to do the following:
   - Rename `inventory/host_vars/{{ domain }}/passwords/postgres` file to `inventory/host_vars/{{ domain }}/passwords/postgres.psk`
   - Copy the `examples/vars.yml` file to `inventory/host_vars/{{ domain }}/vars.yml`
-- Run `ansible-playbook -i inventory/hosts lemmy.yml --become`
+  - Edit your variables as desired
+- Run your regular deployment. Example: `ansible-playbook -i inventory/hosts lemmy.yml --become`
+
+### Upgrading to 1.1.0 (Lemmy 0.18.3)
+
+- No major changes should be required
 
 ## Migrating your existing install to use this deploy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lemmy-Ansible
 
-This provides an easy way to install [Lemmy](https://github.com/LemmyNet/lemmy) on any server. It automatically sets up an nginx server, letsencrypt certificates, and email.
+This provides an easy way to install [Lemmy](https://github.com/LemmyNet/lemmy) on any server. It automatically sets up an nginx server, letsencrypt certificates, docker containers, and email smtp.
 
 ## Requirements
 
@@ -10,6 +10,19 @@ To run this ansible playbook, you need to:
 - Configure a DNS `A` Record to point at your server's IP address.
 - Make sure you can ssh to it, with a sudo user: `ssh <your-user>@<your-domain>`
 - Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on your **local** machine (do not install it on your destination server).
+
+### Supported Distribution Playbook Matrix
+
+These are the distributions we currently support. Anything not listed here is currently not supported.  
+If you wish to see another distribution on the list, please test on the latest commit in `main` and report your findings via an Issue.
+
+| Distribution | Version | Playbook |
+|---|---|---|
+| Debian | 10 | `lemmy.yml` |
+| Debian | 11 | `lemmy.yml` |
+| Debian | 12 | `lemmy.yml` |
+| Ubuntu | 22.04 LTS | `lemmy.yml` |
+| RHEL | 9 | `lemmy-almalinux.yml` |
 
 ## Install
 
@@ -51,15 +64,15 @@ To run this ansible playbook, you need to:
 
    Edit the `inventory/host_vars/<your-domain>/vars.yml` file to your liking.
 
-7. Run the playbook:
+7. Run the playbook: [^1]
 
-   `ansible-playbook -i inventory/hosts lemmy.yml`
+   `ansible-playbook -i inventory/hosts lemmy.yml` 
 
    _Note_: if you are not the root user or don't have password-less sudo, use this command:
 
    `ansible-playbook -i inventory/hosts lemmy.yml --become --ask-become-pass`
 
-   _Note_: if you haven't set up ssh keys[^1], and ssh using a password, use the command:
+   _Note_: if you haven't set up ssh keys[^2], and ssh using a password, use the command:
 
    `ansible-playbook -i inventory/hosts lemmy.yml --become --ask-pass --ask-become-pass`
 
@@ -69,7 +82,8 @@ To run this ansible playbook, you need to:
 
    `interpreter_python=/usr/bin/python3`
 
-[^1]: To create an ssh key pair with your host environment, you can follow the [instructions here](https://www.ssh.com/academy/ssh/keygen#copying-the-public-key-to-the-server), and then copy the key to your host server.
+[^1]: For RHEL distributions please replace `lemmy.yml` with `lemmy-almalinux.yml`
+[^2]: To create an ssh key pair with your host environment, you can follow the [instructions here](https://www.ssh.com/academy/ssh/keygen#copying-the-public-key-to-the-server), and then copy the key to your host server.
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lemmy-Ansible
 
-This provides an easy way to install [Lemmy](https://github.com/LemmyNet/lemmy) on any server. It automatically sets up an nginx server, letsencrypt certificates, docker containers, and email smtp.
+This provides an easy way to install [Lemmy](https://github.com/LemmyNet/lemmy) on any server. It automatically sets up an nginx server, letsencrypt certificates, docker containers, pict-rs, and email smtp.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ To run this ansible playbook, you need to:
 These are the distributions we currently support. Anything not listed here is currently not supported.  
 If you wish to see another distribution on the list, please test on the latest commit in `main` and report your findings via an Issue.
 
-| Distribution | Version | Playbook |
-|---|---|---|
-| Debian | 10 | `lemmy.yml` |
-| Debian | 11 | `lemmy.yml` |
-| Debian | 12 | `lemmy.yml` |
-| Ubuntu | 22.04 LTS | `lemmy.yml` |
-| RHEL | 9 | `lemmy-almalinux.yml` |
+| Distribution | Version   | Playbook              |
+| ------------ | --------- | --------------------- |
+| Debian       | 10        | `lemmy.yml`           |
+| Debian       | 11        | `lemmy.yml`           |
+| Debian       | 12        | `lemmy.yml`           |
+| Ubuntu       | 22.04 LTS | `lemmy.yml`           |
+| RHEL         | 9         | `lemmy-almalinux.yml` |
 
 ## Install
 
@@ -64,15 +64,17 @@ If you wish to see another distribution on the list, please test on the latest c
 
    Edit the `inventory/host_vars/<your-domain>/vars.yml` file to your liking.
 
-7. Run the playbook: [^1]
+7. Run the playbook:
 
-   `ansible-playbook -i inventory/hosts lemmy.yml` 
+   _Note_: See the "Supported Distribution Playbook Matrix" section above if you should use `lemmy.yml` or not
+
+   `ansible-playbook -i inventory/hosts lemmy.yml`
 
    _Note_: if you are not the root user or don't have password-less sudo, use this command:
 
    `ansible-playbook -i inventory/hosts lemmy.yml --become --ask-become-pass`
 
-   _Note_: if you haven't set up ssh keys[^2], and ssh using a password, use the command:
+   _Note_: if you haven't set up ssh keys[^1], and ssh using a password, use the command:
 
    `ansible-playbook -i inventory/hosts lemmy.yml --become --ask-pass --ask-become-pass`
 
@@ -82,13 +84,12 @@ If you wish to see another distribution on the list, please test on the latest c
 
    `interpreter_python=/usr/bin/python3`
 
-[^1]: For RHEL distributions please replace `lemmy.yml` with `lemmy-almalinux.yml`
-[^2]: To create an ssh key pair with your host environment, you can follow the [instructions here](https://www.ssh.com/academy/ssh/keygen#copying-the-public-key-to-the-server), and then copy the key to your host server.
+[^1]: To create an ssh key pair with your host environment, you can follow the [instructions here](https://www.ssh.com/academy/ssh/keygen#copying-the-public-key-to-the-server), and then copy the key to your host server.
 
 ## Upgrading
 
 Since version `1.1.0` we no longer default to using `main` but use tags to make sure deployments are versioned.
-With every new release all migration steps shall be written below so make sure you check out the [Lemmy Releases Changelog](https://github.com/LemmyNet/lemmy/blob/main/RELEASES.md) to see if there are any config changes with the releases since your last.
+With every new release all migration steps shall be written below so make sure you check out the [Lemmy Releases Changelog](https://github.com/LemmyNet/lemmy/blob/main/RELEASES.md) to see if there are any config changes with the releases since your last read.
 
 ### Upgrading to 1.2.0 (Lemmy 0.18.5)
 


### PR DESCRIPTION
# Issue

We still tell people to checkout master rather than the latest tag. 

# Solution
Update docs to specify which tag they should  be checking out

# Notes: 
Also added a quick description on what we have changed since 1.1.0, this will suffice until we get that changelog sorted @codyro 

FYI `git checkout $(git describe --tags)` will always get the latest tag. Currently it gets 0.18.5 instead of 1.1.0 as it is technically newer. Which also contains all the "main" updates, such as the `vars` file changes. This may trip people up if we continue to tag with the lemmy version. 
Getting a process that works for the Lemmy devs should be a priority after we push 1.2.0

Closes: #159 #171 