### PR TITLE
Config fix for postgres docker defaults

### DIFF
--- a/examples/customPostgresql.conf
+++ b/examples/customPostgresql.conf
@@ -28,3 +28,6 @@ temp_file_size=1GB
 synchronous_commit=off
 # This one shouldn't be on regularly, because DB migrations often take a long time
 # statement_timeout = 10000
+
+# Listen beyond localhost
+listen_addresses = '*'

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - ./volumes/postgres:/var/lib/postgresql/data:Z
       - ./customPostgresql.conf:/etc/postgresql.conf
     restart: always
+    command: postgres -c config_file=/etc/postgresql.conf
     logging: *default-logging
 
   postfix:


### PR DESCRIPTION
Default Docker configurations in Alpine have a different override path, which causes problems if people switch to the Ansible deployment.

Reproduction of the issue:
- Fire up a Lemmy DB in Docker without a volume mount for `/etc/postgresql.conf`
- Use `SHOW config_file` to see the location of the config file (it will be in `/var/lib/data`)
- Take down the DB, and add a volume mount for `/etc/postgresql.conf`
- Use `SHOW config_file` to see the location of the config file (it will still be in `/var/lib/data`)

Also, official docker instructions for Postgres is to use `/etc/postgresql/postgresql.conf`, though this is irrelevant given this PR.

To force the use of `/etc/postgresql.conf` for if users switch from bare mode to Ansible, the compose file was edited to include a forced `command`.

In addition, the default for PG15 alpine `listen_address` is `localhost`, not `*`, which is required for the `lemmy` container to connect. This default is overwritten by the docker container normally, but is not included in the tuning samples provided.

***NOTE***: It is highly possible there are a number of smaller self-hosted instances who have no idea their poor performance is because PG is not properly tuned, as the defaults are pretty meager.