### PR TITLE
Adjust permissions for the distributed postgresql.conf

### DIFF
--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -186,9 +186,9 @@
         # src: "files/{{ domain }}/customPostgresql.conf"
         src: "inventory/host_vars/{{ domain }}/customPostgresql.conf"
         dest: "{{ lemmy_base_dir }}/{{ domain }}/customPostgresql.conf"
-        mode: "0600"
-        owner: "1000" # Match UID in container
-        group: "1000" # Match GID in container
+        mode: "0644"
+        owner: root
+        group: root
       tags:
         - configs
         - postgresql

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -223,9 +223,9 @@
           ansible.builtin.template:
             src: "inventory/host_vars/{{ domain }}/customPostgresql.conf"
             dest: "{{ lemmy_base_dir }}/{{ domain }}/customPostgresql.conf"
-            mode: "0600"
-            owner: "1000"
-            group: "1000"
+            mode: "0644"
+            owner: root
+            group: root
 
     - name: Enable and start docker service
       ansible.builtin.systemd:


### PR DESCRIPTION
#183 Got merged prematurely before this could be resolved, so this PR addresses that.

Adjust permissions of the distributed/mounted `customPostgresql.conf` to `root:root` `0644` so the `postgres` user can read the mounted configuration file. 

I opted for `0644` instead of `UID 70:70` `0600` as the `customPostgresql.conf` doesn't carry anything sensitive, and it seems less prone to breakage. 

Refs https://github.com/LemmyNet/lemmy-ansible/pull/183  & https://github.com/LemmyNet/lemmy-ansible/pull/183#issuecomment-1751809582