### PR TITLE
Remove invalid `temp_file_size` line in `customPostgresql.conf`

### DIFF
--- a/examples/customPostgresql.conf
+++ b/examples/customPostgresql.conf
@@ -24,7 +24,6 @@ max_parallel_workers = 4
 max_parallel_maintenance_workers = 2
 
 # Other custom params
-temp_file_size=1GB
 synchronous_commit=off
 # This one shouldn't be on regularly, because DB migrations often take a long time
 # statement_timeout = 10000


### PR DESCRIPTION
Now that customPostgresql.conf is being correctly used, it looks like it has an invalid value which causes PostgreSQL not to start ([#191](https://github.com/LemmyNet/lemmy-ansible/issues/191)). This PR removes the offending line which allows PostgreSQL to start.

```
2023-10-17 01:32:35.372 GMT [1] LOG:  unrecognized configuration parameter "temp_file_size" in file "/etc/postgresql.conf" line 27
2023-10-17 01:32:35.372 GMT [1] FATAL:  configuration file "/etc/postgresql.conf" contains errors
```

@dessalines @Nutomic  If you know what you were using this line for and or what it can be replaced with, let me know.