### PR TITLE
Redirecting version to nodeinfo.

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -63,11 +63,14 @@ http {
         }
 
         # backend
-        location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known|version) {
+        location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
             proxy_pass "http://lemmy:8536";
 
             # Send actual client IP upstream
             include proxy_params;
         }
+
+        # Redirect /version to /nodeinfo/2.0.json
+        rewrite /version /nodeinfo/2.0.json permanent;
     }
 }


### PR DESCRIPTION
Apologies, we decided to go another way with it and just redirect it in nginx.