### PR TITLE
Redirect "/sitemap.xml" to backend

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -63,7 +63,7 @@ http {
         }
 
         # backend
-        location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known|version) {
+        location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known|version|sitemap.xml) {
             proxy_pass "http://lemmy:8536";
 
             # Send actual client IP upstream


### PR DESCRIPTION
Although I don't understand why it only includes the last 24 hours, there is a sitemap endpoint in the backend. So we'd better direct it.

By the way its working on my instance: https://lemy.lol/sitemap.xml