### PR TITLE
Fix installation playbooks running on incompatible OSs

### DIFF
--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -65,11 +65,11 @@
     lemmy_port: "{{ 32767 | random(start=1024) }}"
   tasks:
     - name: Ensure target system is >= EL9
-      ansible.builtin.fail:
-        msg: "This playbook requires Enterprise Linux 9 or greater"
-      when:
-        - ansible_distribution not in ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky']
-        - ansible_distribution_major_version | int < 9
+      ansible.builtin.assert:
+        that:
+          - ansible_distribution in ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky']
+          - ansible_distribution_major_version | int >= 9
+        fail_msg: "This playbook requires Enterprise Linux 9 or greater"
       tags:
         - always
 

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -69,7 +69,7 @@
         that:
           - ansible_distribution in ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky']
           - ansible_distribution_major_version | int >= 9
-        fail_msg: "This playbook requires Enterprise Linux 9 or greater"
+        fail_msg: "This playbook requires Enterprise Linux 9 or greater on the target server"
       tags:
         - always
 

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -69,6 +69,12 @@
         name: nginx
         state: reloaded
   tasks:
+    - name: Ensure target system is Debian or Ubuntu
+      ansible.builtin.assert:
+        that:
+          - ansible_distribution in ['Debian', 'Ubuntu']
+        fail_msg: "This playbook requires Debian or Ubuntu on the target server"
+
     - name: Install aptitude
       ansible.builtin.apt:
         name: aptitude


### PR DESCRIPTION
The Almalinux playbook runs on Ubuntu and Debian, because the current `fail` logic is only succesful when _both_ these conditions are true:

1. Not RHEL
2. Version < 9

So, it will only fail on some obscure system like Ubuntu 8 (side note, if you _are_ trying to install Lemmy on a server with Ubuntu 8 I need answers).

To fix this I changed the `fail` to an `assert` and inverted the conditions. Changing the current "and" clause in the `fail` to an "or" would also make this work but IMO an assertion works better here.