### PR TITLE
#125: Allow HTTP and HTTPS in lemmy.yml

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -99,7 +99,7 @@
           - "python3-setuptools"
 
     - name: Allow HTTP and HTTPS in ufw
-      when: (ansible_distribution == 'Debian') or 
+      when: (ansible_distribution == 'Debian') or
         (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
       ansible.builtin.ufw:
         rule: allow

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -99,6 +99,8 @@
           - "python3-setuptools"
 
     - name: Allow HTTP and HTTPS in ufw
+      when: (ansible_distribution == 'Debian') or 
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
       ansible.builtin.ufw:
         rule: allow
         port: "{{ item }}"

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -101,12 +101,12 @@
     - name: Allow HTTP and HTTPS in ufw
       when: (ansible_distribution == 'Debian') or
         (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
-      ansible.builtin.ufw:
+      community.general.ufw:
         rule: allow
-        port: "{{ item }}"
+        src: "{{ item }}"
       loop:
-        - "http"
-        - "https"
+        - http
+        - https
 
     - name: Configure Docker apt repo for Ubuntu < 22.04
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -99,8 +99,7 @@
           - "python3-setuptools"
 
     - name: Allow HTTP and HTTPS in ufw
-      when: (ansible_distribution == 'Debian') or
-        (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
+      when: (ansible_distribution == 'Debian') or (ansible_distribution == 'Ubuntu')
       community.general.ufw:
         rule: allow
         src: "{{ item }}"

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -98,6 +98,14 @@
           - "virtualenv"
           - "python3-setuptools"
 
+    - name: Allow HTTP and HTTPS in ufw
+      ansible.builtin.ufw:
+        rule: allow
+        port: "{{ item }}"
+      loop:
+        - "http"
+        - "https"
+
     - name: Configure Docker apt repo for Ubuntu < 22.04
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'
       block:


### PR DESCRIPTION
Fixes the issue #125 on Debian and Ubuntu, where letsencrypt thingie went nanners because the ports are closed.