### PR TITLE
fix: nginx real-ips in logs & docker constant resolution for scaling

### DIFF
--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -5,6 +5,12 @@ events {
 }
 
 http {
+    # Docker internal DNS IP so we always get the newer containers without having to 
+    # restart/reload the docker container / nginx configuration
+    resolver 127.0.0.11 valid=5s;
+    # set the real_ip when from docker internal ranges. Ensuring our internal nginx
+    # container can always see the correct ips in the logs
+    set_real_ip_from 172.0.0.0/8;
     # We construct a string consistent of the "request method" and "http accept header"
     # and then apply soem ~simply regexp matches to that combination to decide on the
     # HTTP upstream we should proxy the request to.
@@ -37,6 +43,8 @@ http {
     }
 
     server {
+        set $lemmy_ui "lemmy-ui:1234";
+        set $lemmy "lemmy:8536";
         # this is the port inside docker, not the public one yet
         listen 1236;
         listen 8536;
@@ -59,12 +67,12 @@ http {
 
         # security.txt
         location = /.well-known/security.txt {
-            proxy_pass "http://lemmy-ui:1234";
+            proxy_pass "http://$lemmy_ui";
         }
 
         # backend
         location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known|version|sitemap.xml) {
-            proxy_pass "http://lemmy:8536";
+            proxy_pass "http://$lemmy";
 
             # Send actual client IP upstream
             include proxy_params;


### PR DESCRIPTION
# Problems:
1. nginx internal container didn't correctly display logs of client's 
   Possibly an issue for rate_limits as well? (If rate limits are based on source ips then previously lemmy 'believes' that they are all from the same source)
2. nginx container never refreshed the DNS of "lemmy" or "lemmy-ui". 
   So if you added another lemmy container it would never get the IP of the new container and always send traffic to the old container(s). 

Solutions:
1.  `set_real_ip_from` when it comes from internal docker network
3. Set a resolver to cache for 5 seconds, and set all upstream to variables