### PR TITLE
feat: postgres backup to filesystem

### DIFF
--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -150,6 +150,8 @@
           owner: "root"
         - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/"
           owner: "root"
+        - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/backups/"
+          owner: "root"
         - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/pictrs/"
           owner: "991" # Matches docker-compose UID in docker-compose.yml
 
@@ -191,8 +193,6 @@
       tags:
         - configs
 
-    # TODO: Move to files/, keeping consistent with upstream currently
-    # to ensure documentation is accurate
     - name: Add the customPostgresql.conf
       ansible.builtin.template:
         # src: "files/{{ domain }}/customPostgresql.conf"
@@ -209,11 +209,19 @@
       ansible.builtin.copy:
         src: files/proxy_params
         dest: "{{ lemmy_base_dir }}/{{ domain }}/proxy_params"
+        mode: "0644"
         owner: root
         group: root
-        mode: "0644"
       tags:
         - nginx
+
+    - name: Distribute backup script
+      ansible.builtin.template:
+        src: "tempaltes/backup.sh"
+        dest: "{{ lemmy_base_dir }}/{{ domain }}/backup.sh"
+        mode: "0755"
+        owner: root
+        group: root
 
     - name: Distribute nginx site templates
       ansible.builtin.template:

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -167,6 +167,8 @@
           owner: "root"
         - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/"
           owner: "root"
+        - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/backups/"
+          owner: "root"
         - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/pictrs/"
           owner: "991"
 
@@ -224,6 +226,14 @@
                 src: "../sites-available/{{ domain }}.conf"
                 dest: "/etc/nginx/sites-enabled/{{ domain }}.conf"
                 state: link
+
+        - name: Add backup script
+          ansible.builtin.template:
+            src: "tempaltes/backup.sh"
+            dest: "{{ lemmy_base_dir }}/{{ domain }}/backup.sh"
+            mode: "0755"
+            owner: root
+            group: root
 
         - name: Add the config.hjson
           ansible.builtin.template:

--- a/templates/backup.sh
+++ b/templates/backup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+domain='{{ domain }}'
+backup_path='/dump'
+dump=${domain}_dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql
+
+cd /opt/lemmy/{{ domain }} &&\
+    docker compose exec -T postgres pg_dump -c -U lemmy \
+        --format=custom --file ${backup_path}/${dump}
+

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -99,6 +99,7 @@ services:
 {% endif %}
     volumes:
       - ./volumes/postgres:/var/lib/postgresql/data:Z
+      - ./volumes/backups:/dump:Z
       - ./customPostgresql.conf:/etc/postgresql.conf
     restart: always
     command: postgres -c config_file=/etc/postgresql.conf

--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -5,6 +5,12 @@ events {
 }
 
 http {
+    # Docker internal DNS IP so we always get the newer containers without having to 
+    # restart/reload the docker container / nginx configuration
+    resolver 127.0.0.11 valid=5s;
+    # set the real_ip when from docker internal ranges. Ensuring our internal nginx
+    # container can always see the correct ips in the logs
+    set_real_ip_from 172.0.0.0/8;
     # We construct a string consistent of the "request method" and "http accept header"
     # and then apply soem ~simply regexp matches to that combination to decide on the
     # HTTP upstream we should proxy the request to.
@@ -37,6 +43,8 @@ http {
     }
 
     server {
+        set $lemmy_ui "lemmy-ui:1234";
+        set $lemmy "lemmy:8536";
         # this is the port inside docker, not the public one yet
         listen 1236;
         listen 8536;
@@ -59,12 +67,12 @@ http {
 
         # security.txt
         location = /.well-known/security.txt {
-            proxy_pass "http://lemmy-ui:1234";
+            proxy_pass "http://$lemmy_ui";
         }
 
         # backend
         location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known|version|sitemap.xml) {
-            proxy_pass "http://lemmy:8536";
+            proxy_pass "http://$lemmy";
 
             # Send actual client IP upstream
             include proxy_params;


### PR DESCRIPTION
# Problem

Documented backup solutions [(here)](https://join-lemmy.org/docs/administration/backup_and_restore.html) are inefficient and cause all data from the backup to be piped via the docker console/output rather than directly to a file.

Outputting directly to a file results in atleast a 4x speedup of backups, and does not require docker console to proxy the whole database.

(to be merged after #209)