### PR TITLE
Fix uninstallation not working on Debian

### DIFF
--- a/uninstall.yml
+++ b/uninstall.yml
@@ -29,8 +29,8 @@
       ansible.builtin.meta: end_play
       when: not confirm_uninstall | bool
 
-    - name: Run Ubuntu specific uninstallation steps
-      when: ansible_distribution == "Ubuntu"
+    - name: Run Debian/Ubuntu specific uninstallation steps
+      when: ansible_distribution in ['Debian', 'Ubuntu']
       block:
         - name: Stop docker-compose
           community.docker.docker_compose:


### PR DESCRIPTION
Reduces possibility of Lemmy gaining sentience and taking over the world from your Debian-based server by actually allowing you to uninstall it.