### PR TITLE
Start & enable nginx before requesting SSL certificate (RHEL)

### DIFF
--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -239,8 +239,6 @@
       tags:
         - nginx
 
-
-
     # TODO: Check if this is necessary with EL & podman
     # - name: Copy docker config
     #   ansible.builtin.copy:

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -129,6 +129,17 @@
       tags:
         - firewalld
 
+    - name: Start and enable nginx.service
+      ansible.builtin.systemd:
+        name: nginx.service
+        state: started
+        enabled: true
+      tags:
+        - certbot
+        - certbot_initial
+        - nginx
+        - ssl
+
     # TODO: certbot logic needs to be re-worked
     - name: Request initial letsencrypt certificate
       ansible.builtin.command: certbot certonly --nginx --agree-tos --cert-name '{{ domain }}' -d '{{ domain }}' -m '{{ letsencrypt_contact_email }}'
@@ -227,6 +238,8 @@
       notify: Reload nginx
       tags:
         - nginx
+
+
 
     # TODO: Check if this is necessary with EL & podman
     # - name: Copy docker config


### PR DESCRIPTION
- Fixes issue where certbot starts nginx itself causing a conflict later in the playbook
- Refs https://github.com/LemmyNet/lemmy-ansible/issues/229#issuecomment-1970477648