### PR TITLE
AlmaLinux/RHEL 9 fixes

### DIFF
--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -54,3 +54,6 @@ pictrs_safety_env_vars:
   - secret_key: "{{ pictrs_safety_secret }}"
   - SCAN_BYPASS_THRESHOLD: 10
   - MISSING_WORKER_THRESHOLD: 5
+
+# docker-compose default resolver is 127.0.0.11 while podman-compose is 10.89.0.1
+nginx_internal_resolver: "{{ '127.0.0.11' if ansible_facts['os_family'] != 'RedHat' else '10.89.0.1' }}"

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -239,8 +239,6 @@
       tags:
         - nginx
 
-
-
     # TODO: Check if this is necessary with EL & podman
     # - name: Copy docker config
     #   ansible.builtin.copy:

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -129,6 +129,17 @@
       tags:
         - firewalld
 
+    - name: Start and enable nginx.service
+      ansible.builtin.systemd:
+        name: nginx.service
+        state: started
+        enabled: true
+      tags:
+        - certbot
+        - certbot_initial
+        - nginx
+        - ssl
+
     # TODO: certbot logic needs to be re-worked
     - name: Request initial letsencrypt certificate
       ansible.builtin.command: certbot certonly --nginx --agree-tos --cert-name '{{ domain }}' -d '{{ domain }}' -m '{{ letsencrypt_contact_email }}'
@@ -227,6 +238,8 @@
       notify: Reload nginx
       tags:
         - nginx
+
+
 
     # TODO: Check if this is necessary with EL & podman
     # - name: Copy docker config

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -13,12 +13,6 @@
         fail_msg: "This playbook requires Ansible 2.11.0 or higher"
       become: false
 
-    - name: Disable SELinux
-      ansible.posix.selinux:
-        state: disabled
-      tags:
-        - selinux
-
     # This is not needed for this playbook as it predates its existence
     # But we're keeping it for funsies :)
     - name: Check lemmy_base_dir
@@ -134,6 +128,15 @@
       when: "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
       tags:
         - firewalld
+
+    - name: Adjust SELinux to allow HTTPD scripts and modules to connect to the network
+      ansible.posix.seboolean:
+        name: httpd_can_network_connect
+        state: true
+        persistent: true
+      tags:
+        - nginx
+        - selinux
 
     - name: Start and enable nginx.service
       ansible.builtin.systemd:

--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -13,6 +13,12 @@
         fail_msg: "This playbook requires Ansible 2.11.0 or higher"
       become: false
 
+    - name: Disable SELinux
+      ansible.posix.selinux:
+        state: disabled
+      tags:
+        - selinux
+
     # This is not needed for this playbook as it predates its existence
     # But we're keeping it for funsies :)
     - name: Check lemmy_base_dir

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 {% endfor %}
 {% endif %}
     volumes:
-      - ./volumes/lemmy-ui/extra_themes:/app/extra_themes
+      - ./volumes/lemmy-ui/extra_themes:/app/extra_themes:Z
     depends_on:
       - lemmy
     restart: always
@@ -99,7 +99,7 @@ services:
 {% endif %}
     volumes:
       - ./volumes/postgres:/var/lib/postgresql/data:Z
-      - ./customPostgresql.conf:/etc/postgresql.conf
+      - ./customPostgresql.conf:/etc/postgresql.conf:Z
     restart: always
     command: postgres -c config_file=/etc/postgresql.conf
     shm_size: 1g

--- a/templates/nginx_internal.conf
+++ b/templates/nginx_internal.conf
@@ -7,7 +7,7 @@ events {
 http {
     # Docker internal DNS IP so we always get the newer containers without having to 
     # restart/reload the docker container / nginx configuration
-    resolver 127.0.0.11 valid=5s;
+    resolver {{ nginx_internal_resolver }} valid=5s;
     # set the real_ip when from docker internal ranges. Ensuring our internal nginx
     # container can always see the correct ips in the logs
     set_real_ip_from 172.0.0.0/8;


### PR DESCRIPTION
Ensures `lemmy-almalinux.yml` runs on a clean AlmaLinux/RHEL9 instance.

- Move internal nginx resolver to variable/conditional based off `os_family`
- Modify SELinux in the `lemmy-almalinux.yml` playbook to ensure clean run
- Modify `docker-compose.yml` template to ensure SELinux label gets applied (`:Z`)
- ~~Start & Enable nginx earlier in the playbook to avoid conflict~~ (Already merged in https://github.com/LemmyNet/lemmy-ansible/pull/230)
- Refs https://github.com/LemmyNet/lemmy-ansible/issues/229
