### PR TITLE
Add missing ansible tags

### DIFF
--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -172,6 +172,8 @@
           owner: "root"
         - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/pictrs/"
           owner: "991" # Matches docker-compose UID in docker-compose.yml
+      tags:
+        - directories
 
     - name: Set lemmy_port fact
       ansible.builtin.set_fact:

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -15,11 +15,15 @@
           - "ansible_version.full is version('2.11.0', '>=')"
         fail_msg: "This playbook requires Ansible 2.11.0 or higher"
       become: false
+      tags:
+        - always
 
     - name: Check lemmy_base_dir
       ansible.builtin.fail:
         msg: "`lemmy_base_dir` is unset. if you are upgrading from an older version, add `lemmy_base_dir=/lemmy` to your inventory file."
       when: lemmy_base_dir is not defined
+      tags:
+        - always
 
     - name: Check for legacy passwords/postgres file
       delegate_to: localhost
@@ -27,6 +31,8 @@
         path: "inventory/host_vars/{{ domain }}/passwords/postgres"
       register: postgres_password_file
       become: false
+      tags:
+        - always
 
     - name: Legacy use of passwords/postgres file
       delegate_to: localhost
@@ -36,6 +42,8 @@
           See https://github.com/LemmyNet/lemmy-ansible#upgrading
       when: postgres_password_file.stat.exists
       become: false
+      tags:
+        - always
 
     - name: Check for vars.yml file
       delegate_to: localhost
@@ -43,6 +51,8 @@
         path: "inventory/host_vars/{{ domain }}/vars.yml"
       register: vars_file
       become: false
+      tags:
+        - always
 
     - name: Missing vars.yml file
       delegate_to: localhost
@@ -52,6 +62,8 @@
           and https://github.com/LemmyNet/lemmy-ansible#upgrading
       when: not vars_file.stat.exists
       become: false
+      tags:
+        - always
 
     - name: Install python for Ansible
       # python2-minimal instead of python-minimal for ubuntu 20.04 and up
@@ -60,20 +72,29 @@
         executable: /bin/bash
       register: output
       changed_when: output.stdout != ''
+      tags:
+        - always
+        - dependencies
 
     - name: Gather facts
       ansible.builtin.setup:
+      tags:
+        - always
+
   handlers:
     - name: Reload nginx
       ansible.builtin.systemd:
         name: nginx
         state: reloaded
+
   tasks:
     - name: Ensure target system is Debian or Ubuntu
       ansible.builtin.assert:
         that:
           - ansible_distribution in ['Debian', 'Ubuntu']
         fail_msg: "This playbook requires Debian or Ubuntu on the target server"
+      tags:
+        - always
 
     - name: Install dependencies
       ansible.builtin.apt:
@@ -91,9 +112,14 @@
           - "python3-pip"
           - "virtualenv"
           - "python3-setuptools"
+      tags:
+        - dependencies
 
     - name: Configure Docker apt repo for Ubuntu < 22.04
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'
+      tags:
+        - dependencies
+        - docker
       block:
         - name: Add Docker GPG apt Key
           ansible.builtin.apt_key:
@@ -110,6 +136,9 @@
       ansible.builtin.command: dpkg --print-architecture
       register: dpkg_output
       changed_when: false
+      tags:
+        - dependencies
+        - docker
 
     # based on https://docs.docker.com/engine/install/debian/
     # and https://docs.docker.com/engine/install/ubuntu/
@@ -117,6 +146,9 @@
     - name: Configure Docker apt repo for Debian or Ubuntu >= 22.04
       when: (ansible_distribution == 'Debian') or
         (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '22.04')
+      tags:
+        - dependencies
+        - docker
       block:
         - name: Download Docker GPG Key
           ansible.builtin.get_url:
@@ -138,17 +170,26 @@
           - docker-compose
         state: present
         update_cache: true
+      tags:
+        - dependencies
+        - docker
 
     - name: Copy docker config
       ansible.builtin.copy:
         src: files/docker-daemon.json
         dest: /etc/docker/daemon.json
         mode: "0644"
+      tags:
+        - docker
 
     - name: Request initial letsencrypt certificate
       ansible.builtin.command: certbot certonly --nginx --agree-tos --cert-name '{{ domain }}' -d '{{ domain }}' -m '{{ letsencrypt_contact_email }}'
       args:
         creates: "/etc/letsencrypt/live/{{ domain }}/privkey.pem"
+      tags:
+        - certbot
+        - certbot_initial
+        - ssl
 
     - name: Create lemmy folder
       ansible.builtin.file:
@@ -163,12 +204,16 @@
           owner: "root"
         - path: "{{ lemmy_base_dir }}/{{ domain }}/volumes/pictrs/"
           owner: "991"
+      tags:
+        - directories
 
     - name: Deploy configuration files
       block:
         - name: Generate random port for lemmy service
           ansible.builtin.set_fact:
             lemmy_port: "{{ 32767 | random(start=1024) }}"
+          tags:
+            - always
 
         - name: Distribute nginx proxy_params configuration
           ansible.builtin.copy:
@@ -178,6 +223,9 @@
             group: root
             mode: "0644"
           notify: Reload nginx
+          tags:
+            - configs
+            - nginx
 
         - name: Add template files
           ansible.builtin.template:
@@ -198,9 +246,16 @@
           vars:
             lemmy_docker_image: "dessalines/lemmy:{{ lemmy_version | default(lookup('file', 'VERSION')) }}"
             lemmy_docker_ui_image: "dessalines/lemmy-ui:{{ lemmy_ui_version | default(lemmy_version | default(lookup('file', 'VERSION'))) }}"
+          tags:
+            - configs
+            - nginx
+            - docker
 
         - name: Set up nginx sites-enabled symlink
           notify: Reload nginx
+          tags:
+            - configs
+            - nginx
           block:
             - name: Gather stats on site enabled config
               ansible.builtin.stat:
@@ -226,6 +281,8 @@
             mode: "0600"
             owner: "1000"
             group: "1000"
+          tags:
+            - configs
 
         - name: Add the customPostgresql.conf
           ansible.builtin.template:
@@ -234,12 +291,17 @@
             mode: "0644"
             owner: root
             group: root
+          tags:
+            - configs
+            - postgresql
 
     - name: Enable and start docker service
       ansible.builtin.systemd:
         name: docker
         enabled: true
         state: started
+      tags:
+        - docker
 
     # - name: Change the working directory to /opt
     #   ansible.builtin.shell:
@@ -254,6 +316,8 @@
         state: present
         pull: true
         remove_orphans: true
+      tags:
+        - docker
 
     - name: Certbot renewal cronjob
       ansible.builtin.cron:
@@ -261,3 +325,6 @@
         name: certbot-renew-lemmy
         user: root
         job: "certbot certonly --nginx --cert-name '{{ domain }}' -d '{{ domain }}' --deploy-hook 'nginx -s reload'"
+      tags:
+        - certbot
+        - ssl


### PR DESCRIPTION
Added tags to `lemmy.yml` and `lemmy-almalinux.yml`. Hope they look fine, pls suggest if there's any that can be changed. 

Also, this will kinda sorta help with #189 because you can run something like `ansible-playbook lemmy.yml --skip-tags ssl` that will effectively bypass everything related to ssl in case you want to reuse existing certificates (or your setup is like mine where I test out the files within WSL/vagrant without a valid domain).

Honestly speaking I wouldn't recommend running the playbook solely relying on tags at all unless you're extremely familiar with both the playbook and ansible, but it can be used for cases like I mentioned.

I don't think `uninstall.yml` needs tags because it completely works on user input so I didn't bother.