### PR TITLE
Add cron to dependencies

### DIFF
--- a/lemmy-almalinux.yml
+++ b/lemmy-almalinux.yml
@@ -96,6 +96,7 @@
         state: present
         name:
           - certbot
+          - cronie
           - curl
           - nginx
           - podman

--- a/lemmy.yml
+++ b/lemmy.yml
@@ -91,6 +91,7 @@
           - "python3-pip"
           - "virtualenv"
           - "python3-setuptools"
+          - "cron"
 
     - name: Configure Docker apt repo for Ubuntu < 22.04
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'


### PR DESCRIPTION
Cron seems to be required:
```
TASK [Certbot renewal cronjob] *************************************************
fatal: [foresight.wiki]: FAILED! => {"changed": false, "msg": "Failed to find required executable \"crontab\" in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
```