### PR TITLE
Move to docker_compose_v2 action

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -312,10 +312,10 @@
     # - debug: var=shell_output
 
     - name: Start docker-compose
-      community.docker.docker_compose:
+      community.docker.docker_compose_v2:
         project_src: "{{ lemmy_base_dir }}/{{ domain }}"
         state: present
-        pull: true
+        pull: always
         remove_orphans: true
       tags:
         - docker


### PR DESCRIPTION
As detailed in https://github.com/LemmyNet/lemmy-ansible/issues/239, the `community.docker.docker_compose` action from the [community.docker](https://github.com/ansible-collections/community.docker) Ansible collection has been deprecated in favor of `community.docker.docker_compose_v2`.

This was discovered while debugging a problem running the `lemmy.yml` playbook on an Ubuntu 24.04 system with Python 3.12, which broke during the `docker_compose` step due to an incompatibility with a newer version of `urllib3` (https://github.com/docker/docker-py/issues/3113). The problem was [fixed](https://github.com/ansible-collections/community.docker/blob/main/CHANGELOG.md#v3-4-5), but apparently only in the `docker_compose_v2` action. The result is that the deprecated `docker_compose` action doesn't work with newer versions of Python, but `docker_compose_v2` does.

This PR is a simple change to `lemmy.yml` to use `docker_compose_v2`. One minor incompatibility is addressed by changing the `pull` parameter from `true` to `always`, since `v2` changed it from a boolean to a string with the possible values of "always", "missing", "never", and "policy" (documented [here](https://github.com/ansible-collections/community.docker/blob/9beac01ce1a36b48ad2fe7c8389688535c2e483e/plugins/modules/docker_compose_v2.py#L54-L60)). The value "missing" might be fine as well, but "always" seemed like a safe value to use.