### PR TITLE
feat: remove open port & enable docker live-restore

### DIFF
--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -1,4 +1,4 @@
-postgres_password: "{{ lookup('password', 'inventory/host_vars/{{ domain }}/passwords/postgres.psk chars=ascii_letters,digits') }}" # noqa yaml[line-length]:w
+postgres_password: "{{ lookup('password', 'inventory/host_vars/{{ domain }}/passwords/postgres.psk chars=ascii_letters,digits') }}" # noqa yaml[line-length]
 
 # Next two only relevant if pictrs_safety == True
 pictrs_safety_worker_auth: "{{ lookup('password', 'inventory/host_vars/{{ domain }}/passwords/pictrs_safety_worker_auth.psk chars=ascii_letters,digits length=15') }}" # noqa yaml[line-length]

--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -3,5 +3,6 @@
   "log-opts": {
     "max-file": "10",
     "max-size": "100m"
-  }
+  },
+  "live-restore": true
 }

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -36,6 +36,53 @@ services:
 {% endif %}
     volumes:
       - ./lemmy.hjson:/config/config.hjson:Z
+    command:
+      - "--disable-scheduled-tasks"
+      - "--disable-activity-sending"
+    depends_on:
+      - postgres
+      - pictrs
+
+  lemmy-schedule:
+    image: {{ lemmy_docker_image }}
+    hostname: lemmy-schedule
+    restart: always
+    logging: *default-logging
+    environment:
+{% if lemmy_env_vars is defined and lemmy_env_vars|length > 0 %}
+{% for item in lemmy_env_vars %}
+{% for key, value in item.items() %}
+      - {{ key }}={{ value }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+    volumes:
+      - ./lemmy.hjson:/config/config.hjson:Z
+    command:
+      - "--disable-activity-sending"
+      - "--disable-http-server"
+    depends_on:
+      - postgres
+      - pictrs
+
+  lemmy-federate:
+    image: {{ lemmy_docker_image }}
+    hostname: lemmy-federate
+    restart: always
+    logging: *default-logging
+    environment:
+{% if lemmy_env_vars is defined and lemmy_env_vars|length > 0 %}
+{% for item in lemmy_env_vars %}
+{% for key, value in item.items() %}
+      - {{ key }}={{ value }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+    volumes:
+      - ./lemmy.hjson:/config/config.hjson:Z
+    command:
+      - "--disable-scheduled-tasks"
+      - "--disable-http-server"
     depends_on:
       - postgres
       - pictrs

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -8,9 +8,7 @@ services:
   proxy:
     image: docker.io/library/nginx 
     ports:
-      # actual and only port facing any connection from outside
-      # Note, change the left number if port 1236 is already in use on your system
-      # You could use port 80 if you won't use a reverse proxy
+      # Note, change lemmy_port in vars.yml if it is already in use on your system
       - "127.0.0.1:{{ lemmy_port }}:8536"
     volumes:
       - ./nginx_internal.conf:/etc/nginx/nginx.conf:ro,Z
@@ -36,53 +34,6 @@ services:
 {% endif %}
     volumes:
       - ./lemmy.hjson:/config/config.hjson:Z
-    command:
-      - "--disable-scheduled-tasks"
-      - "--disable-activity-sending"
-    depends_on:
-      - postgres
-      - pictrs
-
-  lemmy-schedule:
-    image: {{ lemmy_docker_image }}
-    hostname: lemmy-schedule
-    restart: always
-    logging: *default-logging
-    environment:
-{% if lemmy_env_vars is defined and lemmy_env_vars|length > 0 %}
-{% for item in lemmy_env_vars %}
-{% for key, value in item.items() %}
-      - {{ key }}={{ value }}
-{% endfor %}
-{% endfor %}
-{% endif %}
-    volumes:
-      - ./lemmy.hjson:/config/config.hjson:Z
-    command:
-      - "--disable-activity-sending"
-      - "--disable-http-server"
-    depends_on:
-      - postgres
-      - pictrs
-
-  lemmy-federate:
-    image: {{ lemmy_docker_image }}
-    hostname: lemmy-federate
-    restart: always
-    logging: *default-logging
-    environment:
-{% if lemmy_env_vars is defined and lemmy_env_vars|length > 0 %}
-{% for item in lemmy_env_vars %}
-{% for key, value in item.items() %}
-      - {{ key }}={{ value }}
-{% endfor %}
-{% endfor %}
-{% endif %}
-    volumes:
-      - ./lemmy.hjson:/config/config.hjson:Z
-    command:
-      - "--disable-scheduled-tasks"
-      - "--disable-http-server"
     depends_on:
       - postgres
       - pictrs

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       # actual and only port facing any connection from outside
       # Note, change the left number if port 1236 is already in use on your system
       # You could use port 80 if you won't use a reverse proxy
-      - "{{ lemmy_port }}:8536"
+      - "127.0.0.1:{{ lemmy_port }}:8536"
     volumes:
       - ./nginx_internal.conf:/etc/nginx/nginx.conf:ro,Z
       - ./proxy_params:/etc/nginx/proxy_params:ro,Z


### PR DESCRIPTION
Here we give a QOL update to lemmy-ansible.

- move to using a dedicated container by default for schedule, federate, and api
- close the open port that everyone seems to forgot about
- enable the live-restore so everyone can update docker without fear of their lemmy server going down
- cleanup a vim issue
