### PR TITLE
Switch PostgreSQL container to use pgautoupgrade

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     logging: *default-logging
 
   postgres:
-    image: pgautoupgrade/pgautoupgrade:16-alpine
+    image: docker.io/pgautoupgrade/pgautoupgrade:16-alpine
     hostname: postgres
     environment:
 {% if postgres_env_vars is defined and postgres_env_vars|length > 0 %}

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     logging: *default-logging
 
   postgres:
-    image: docker.io/postgres:16-alpine
+    image: pgautoupgrade/pgautoupgrade:16-alpine
     hostname: postgres
     environment:
 {% if postgres_env_vars is defined and postgres_env_vars|length > 0 %}


### PR DESCRIPTION
Lemmy changed from PostgreSQL 15 to 16 at some point, and trying to switch from 15 to 16 in `docker-compose.yml` results in errors like this at startup:

> DETAIL:  The data directory was initialized by PostgreSQL version 15, which is not compatible with this version 16.3

This PR changes the PostgreSQL container to use [pgautoupgrade](https://github.com/pgautoupgrade/docker-pgautoupgrade). The pgautoupgrade image is based on the regular PostgreSQL one, but it automatically updates the data to the newer format on startup. This avoids users having to [figure it out manually](https://github.com/docker-library/postgres/issues/37).

Same change as in https://github.com/LemmyNet/lemmy/pull/4892