### PR TITLE
Pin ansible version for CI

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,11 +7,8 @@ steps:
       - event: pull_request
 
   check_ansible_format:
-    image: alpine:3
+    image: alpine/ansible:2.17.0
     commands:
-      - export PATH=/root/.local/bin:$${PATH}
-      - apk add pipx
-      - pipx install --include-deps ansible
       - ansible-playbook lemmy.yml --syntax-check
       - ansible-playbook lemmy-almalinux.yml --syntax-check
       - ansible-playbook uninstall.yml --syntax-check
@@ -19,12 +16,8 @@ steps:
       - event: pull_request
 
   ansible_lint:
-    image: alpine:3
+    image: alpine/ansible:2.17.0
     commands:
-      - export PATH=/root/.local/bin:$${PATH}
-      - apk add pipx
-      - pipx install --include-deps ansible
-      - pipx inject --include-deps ansible ansible-lint
       - ansible-lint --warn-list experimental lemmy.yml lemmy-almalinux.yml uninstall.yml examples/vars.yml
     when:
       - event: pull_request

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -7,7 +7,7 @@ steps:
       - event: pull_request
 
   check_ansible_format:
-    image: alpine/ansible:2.17.0
+    image: pipelinecomponents/ansible-lint:0.75.0
     commands:
       - ansible-playbook lemmy.yml --syntax-check
       - ansible-playbook lemmy-almalinux.yml --syntax-check
@@ -16,7 +16,7 @@ steps:
       - event: pull_request
 
   ansible_lint:
-    image: alpine/ansible:2.17.0
+    image: pipelinecomponents/ansible-lint:0.75.0
     commands:
       - ansible-lint --warn-list experimental lemmy.yml lemmy-almalinux.yml uninstall.yml examples/vars.yml
     when:


### PR DESCRIPTION
Right now we are simply using the latest version, which breaks if there is a new lint added (see [here](https://woodpecker.join-lemmy.org/repos/130/pipeline/458/4)). Also we can use a premade docker image instead of installing ansible manually.