### PR TITLE
Remove gzip compression from nginx config

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -40,13 +40,6 @@ server {
     # Upload limit, relevant for pictrs
     client_max_body_size 20M;
 
-    # Enable compression for JS/CSS/HTML bundle, for improved client load times.
-    # It might be nice to compress JSON, but leaving that out to protect against potential
-    # compression+encryption information leak attacks like BREACH.
-    gzip on;
-    gzip_types text/css application/javascript image/svg+xml;
-    gzip_vary on;
-
     # Various content security headers
     add_header Referrer-Policy "same-origin";
     add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
This is already handled in lemmy backend using [actix-web compression middleware](https://docs.rs/actix-web/latest/actix_web/middleware/struct.Compress.html) (also in 0.19). It also supports brotli and zstd besides gzip.

```bash
curl "https://lemmy.ml/api/v3/comment/list?post_id=3192572" -so /dev/null --compressed -v 2>&1 | grep content-encoding:
< content-encoding: br
```