### PR TITLE
fix installation of cron dependency

### DIFF
--- a/lemmy.yml
+++ b/lemmy.yml
@@ -112,9 +112,9 @@
           - "python3-pip"
           - "virtualenv"
           - "python3-setuptools"
+          - "cron"
       tags:
         - dependencies
-          - "cron"
 
     - name: Configure Docker apt repo for Ubuntu < 22.04
       when: ansible_distribution == 'Ubuntu' and ansible_distribution_version < '22.04'


### PR DESCRIPTION
#238 added the installation of cron as dependency, but the merge of #236 accidentally inserted a tags section in the middle of the packages to be installed