### PR TITLE
fix range requests for video streaming

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,6 +1,7 @@
 limit_req_zone $binary_remote_addr zone={{ domain }}_ratelimit:10m rate=1r/s;
 proxy_cache_path /var/cache/lemmy/{{domain}}/ levels=1:2 keys_zone=lemmy_cache_{{domain|replace(".","_")|replace("-","_")}}:10m max_size=100m use_temp_path=off;
-proxy_cache_key $scheme$proxy_host$request_uri$http_accept;
+proxy_cache_key $scheme$proxy_host$request_uri$http_accept$slice_range;
+slice 1m;
 
 server {
     listen 80;
@@ -62,6 +63,7 @@ server {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Range $slice_range;
 
       proxy_cache lemmy_cache_{{domain|replace(".","_")|replace("-","_")}};
       proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;


### PR DESCRIPTION
This PR enables streaming video content for all clients. It also fixes video support on Safari (where videos refused to play at all).

This pr uses [the nginx slice module](https://nginx.org/en/docs/http/ngx_http_slice_module.html) to properly cache and serve partial responses to the client.

I have set nginx to cache by slicing files into 1mb chunks. Let me know if you would like this adjusted!

I've tested this on my server - the following video should play in Safari, whereas before it refused to play: https://lt.harding.dev/pictrs/image/88aaf722-b9d5-4e72-88c4-63e5e9a1bc42.mp4

Resolves LemmyNet/lemmy#5356