### PR TITLE
Add back Host header

### DIFF
--- a/files/proxy_params
+++ b/files/proxy_params
@@ -1,1 +1,2 @@
+proxy_set_header Host $host;
 proxy_set_header X-Forwarded-For $remote_addr;

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -56,6 +56,7 @@ server {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header Range $slice_range;
 


### PR DESCRIPTION
This is actually necessary, removing it broke incoming federation on lemmy.ml. Reverts part of https://github.com/LemmyNet/lemmy-ansible/pull/292.